### PR TITLE
Automatic Data Refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ For example, if you have a component called `Profile` that has a `userId` prop, 
 
     connect(props => {
      return {
-       userFetch:  `/users/${props.userId}`
-       likesFetch: `/users/${props.userId}/likes`
+       userFetch:  `/users/${props.userId}`,
+       likesFetch: `/likes/${props.userId}/likes`
      }
     })(Profile)
  
@@ -37,7 +37,7 @@ When the component mounts, the URLs will be calculated, fetched, and the result 
 
 When new props are received, the URLs are re-calculated, and if they changed, the data is refetched and passed into the component as new `PromiseState`s. When refetching, the `PromiseState` will be `pending` and the `value` will be `null`.
 
-If the`refreshInterval` option is provided with a URL, the data will be refreshed at the provided interval in milliseconds. In this example, `likesFetch` will be refreshed every minute:
+If the `refreshInterval` option is provided with a URL, the data will be refreshed at the provided interval in milliseconds. In this example, `likesFetch` will be refreshed every minute:
 
     connect(props => {
      return {

--- a/README.md
+++ b/README.md
@@ -8,9 +8,13 @@ React bindings for URL data.
 [![build status](https://img.shields.io/travis/heroku/react-refetch/master.svg?style=flat-square)](https://travis-ci.org/heroku/react-refetch) [![npm version](https://img.shields.io/npm/v/react-refetch.svg?style=flat-square)](https://www.npmjs.com/package/react-refetch)
 [![npm downloads](https://img.shields.io/npm/dm/react-refetch.svg?style=flat-square)](https://www.npmjs.com/package/react-refetch)
 
-This project was inspired by (and forked from) [react-redux](https://github.com/rackt/react-redux). Redux/Flux is a wonderful library/pattern for applications that need to maintain complicated client-side state; however, if your application is just fetching and rendering read-only data from a server, it can over-complicate the architecture to fetch data in actions, reduce it into the store, only to select it back out again. The other approach of fetching data [inside](https://facebook.github.io/react/tips/initial-ajax.html) the component and dumping it in local state is also messy and makes components smarter and more mutable than they need to be. This module allows you to wrap a component in a `connect()` decorator like react-redux, but instead of mapping state to props, this let's you map props to URLs (or `Request`s) to props. 
+## Motivation
 
-For example, if you have a component called `Profile` that has a `userId` prop, you can wrap it in `connect()` to map `userId` to one or more URLs and assigned to new props called `userFetch` and `likesFetch`:
+This project was inspired by (and forked from) [react-redux](https://github.com/rackt/react-redux). Redux/Flux is a wonderful library/pattern for applications that need to maintain complicated client-side state; however, if your application is just fetching and rendering read-only data from a server, it can over-complicate the architecture to fetch data in actions, reduce it into the store, only to select it back out again. The other approach of fetching data [inside](https://facebook.github.io/react/tips/initial-ajax.html) the component and dumping it in local state is also messy and makes components smarter and more mutable than they need to be. This module allows you to wrap a component in a `connect()` decorator like react-redux, but instead of mapping state to props, this let's you map props to URLs to props. 
+
+## Example
+
+If you have a component called `Profile` that has a `userId` prop, you can wrap it in `connect()` to map `userId` to one or more URLs and assigned to new props called `userFetch` and `likesFetch`:
 
     connect(props => {
      return {
@@ -35,9 +39,13 @@ When the component mounts, the URLs will be calculated, fetched, and the result 
       // similar for `likesFetch`
     }
 
-When new props are received, the URLs are re-calculated, and if they changed, the data is refetched and passed into the component as new `PromiseState`s. When refetching, the `PromiseState` will be `pending` and the `value` will be `null`.
+## Refetching
 
-If the `refreshInterval` option is provided with a URL, the data will be refreshed at the provided interval in milliseconds. In this example, `likesFetch` will be refreshed every minute:
+When new props are received, the URLs are re-calculated, and if they changed, the data is *refetched* and passed into the component as new `PromiseState`s. When refetching (not to be confused with *refreshing* explained below), the `PromiseState` will be reset to `pending` with the `value` set to `null`.
+
+## Refreshing
+
+If the `refreshInterval` option is provided along with a URL, the data will be refreshed that many milliseconds after the last successful response. If a request was ever rejected, it will not be refreshed or otherwise retried. In this example, `likesFetch` will be refreshed every minute:
 
     connect(props => {
      return {
@@ -46,7 +54,7 @@ If the `refreshInterval` option is provided with a URL, the data will be refresh
      }
     })(Profile)
  
-When refreshing, the `PromiseState` will be `refreshing`, `pending` will be `false`, and its `value` will still be set to the previously fulfilled value. Data will only be refreshed after a successful fulfillment. If a fetch is rejected, it will not be refreshed or otherwise retried.
+When refreshing, the `PromiseState` will be the same as a the previous `fulfilled` state, but with the `refreshing` attribute set. That is, `pending` will remain unset and the existing `value` will be left in tact. When the refresh completes, `refreshing` will be unset and the `value` will be updated with the latest data. If the refresh is rejected, the `PromiseState` will move into a `rejected` and not attempt to refresh again. 
  
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,19 @@ When the component mounts, the URLs will be calculated, fetched, and the result 
       // similar for `likesFetch`
     }
 
-When new props are received, the URLs are re-calculated, and if they changed, the data is refetched and passed into the component as new `PromiseState`s.
+When new props are received, the URLs are re-calculated, and if they changed, the data is refetched and passed into the component as new `PromiseState`s. When refetching, the `PromiseState` will be `pending` and the `value` will be `null`.
+
+If the`refreshInterval` option is provided with a URL, the data will be refreshed at the provided interval in milliseconds. 
+In this example, `likesFetch` will be refreshed every minute:
+
+    connect(props => {
+     return {
+       userFetch:  `/users/${props.userId}`,
+       likesFetch: [`/likes/${props.userId}/likes`, { refreshInterval: 60000 }]
+     }
+    })(Profile)
+ 
+When refreshing, the `PromiseState` will be `refreshing`, `pending` will be `false`, and its `value` will still be set to the previously fulfilled value.
  
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ When the component mounts, the URLs will be calculated, fetched, and the result 
 
 When new props are received, the URLs are re-calculated, and if they changed, the data is refetched and passed into the component as new `PromiseState`s. When refetching, the `PromiseState` will be `pending` and the `value` will be `null`.
 
-If the`refreshInterval` option is provided with a URL, the data will be refreshed at the provided interval in milliseconds. 
-In this example, `likesFetch` will be refreshed every minute:
+If the`refreshInterval` option is provided with a URL, the data will be refreshed at the provided interval in milliseconds. In this example, `likesFetch` will be refreshed every minute:
 
     connect(props => {
      return {
@@ -47,7 +46,7 @@ In this example, `likesFetch` will be refreshed every minute:
      }
     })(Profile)
  
-When refreshing, the `PromiseState` will be `refreshing`, `pending` will be `false`, and its `value` will still be set to the previously fulfilled value.
+When refreshing, the `PromiseState` will be `refreshing`, `pending` will be `false`, and its `value` will still be set to the previously fulfilled value. Data will only be refreshed after a successful fulfillment. If a fetch is rejected, it will not be refreshed or otherwise retried.
  
 ## Installation
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -20,9 +20,9 @@ A React component class that injects the synchronous state of the resulting data
 
   *  - pending: true if data is still being loaded for the first time
   *  - refreshing: true if data was successfully loaded and is being refreshed
-  *  - fulfilled: true if data was loaded successfully and is not being refreshed
+  *  - fulfilled: true if data was loaded successfully
   *  - rejected: true if data was loaded unsuccessfully
-  *  - settled: true if data was load completed, if successfully or unsuccessfully
+  *  - settled: true if the data load completed, if successfully or unsuccessfully
   *  - value: value of successfully loaded data; otherwise, null
   *  - reason: error of unsuccessfully loaded data; otherwise, null
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,6 +1,6 @@
 ## API
 
-### `connect([mapPropsToRequestsToProps])`
+### `connect([mapPropsToRequestsToProps], [options])`
 
 Connects a React component to data from one or more URLs.
 
@@ -9,7 +9,7 @@ Instead, it *returns* a new, connected component class, for you to use.
 
 #### Arguments
 
-* [`mapPropsToRequestsToProps(props): urlProps`] \(*Function*): If specified, the component will fetch data from the URLs. Any time props update, `mapPropsToRequestsToProps` will be called. Its result must be a plain object mapping prop keys to URL strings or `window.Request` objects. If the values changed, they will be passed to `window.fetch` and the synchronous state of the resulting promise will be serialized and merged into the component’s props. If you omit it, the component will not be connected to any URLs. 
+* [`mapPropsToRequestsToProps(props): { prop: [url|window.Request, {option: value, ...}], ... }`] \(*Function*): If specified, the component will fetch data from the URLs. Any time props update, `mapPropsToRequestsToProps` will be called. Its result must be a plain object mapping prop keys to URL strings or `window.Request` objects. An additional options argument can be supplied as an object within an array. The only option supported is `refreshInterval` to be supplied in milliseconds. If the values changed, they will be passed to `window.fetch` and the synchronous state of the resulting promise will be serialized and merged into the component’s props. If omitted, the component will not be connected to any URLs. 
 
 * [`options`] *(Object)* If specified, further customizes the behavior of the connector.
   * [`withRef = false`] *(Boolean)*: If true, stores a ref to the wrapped component instance and makes it available via `getWrappedInstance()` method. *Defaults to `false`.*
@@ -18,14 +18,15 @@ Instead, it *returns* a new, connected component class, for you to use.
 
 A React component class that injects the synchronous state of the resulting data promises into your component as a `PromiseState` object with the following properties:
 
-  *  - pending: true if data is still being loaded
-  *  - fulfilled: true if data was loaded successfully
+  *  - pending: true if data is still being loaded for the first time
+  *  - refreshing: true if data was successfully loaded and is being refreshed
+  *  - fulfilled: true if data was loaded successfully and is not being refreshed
   *  - rejected: true if data was loaded unsuccessfully
   *  - settled: true if data was load completed, if successfully or unsuccessfully
   *  - value: value of successfully loaded data; otherwise, null
   *  - reason: error of unsuccessfully loaded data; otherwise, null
 
-##### Static Properties
+##### Static Properties'
 
 * `WrappedComponent` *(Component)*: The original component class passed to `connect()`.
 
@@ -68,7 +69,7 @@ Returns the wrapped component instance. Only available if you pass `{ withRef: t
     // declare the URLs for fetching the data assigned to keys and connect the component.
     export default connect(props => {
      return {
-       userFetch:  `/users/${props.params.userId}`
-       likesFetch: `/likes/${props.params.userId}/likes`
+       userFetch:  `/users/${props.params.userId}`,
+       likesFetch: [`/likes/${props.userId}/likes`, { refreshInterval: 60000 }]
      }
     })(Profile)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-refetch",
-  "version": "0.1.1-beta.0",
+  "version": "0.1.1-beta.1",
   "description": "React bindings for URL data",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-refetch",
-  "version": "0.1.1-beta.1",
+  "version": "0.1.1-beta.2",
   "description": "React bindings for URL data",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "react-refetch",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "description": "React bindings for URL data",
   "main": "./lib/index.js",
   "scripts": {
     "build": "babel src --out-dir lib",
     "clean": "rimraf lib dist coverage",
     "lint": "eslint src test",
-    "prepublish": "npm run clean && npm run build",
+    "prepublish": "npm run clean && npm run lint && npm run build",
     "test": "mocha --compilers js:babel/register --recursive --require ./test/setup.js",
     "test:watch": "npm test -- --watch",
     "test:cov": "babel-node ./node_modules/isparta/bin/isparta cover ./node_modules/mocha/bin/_mocha -- --recursive"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-refetch",
-  "version": "0.1.0",
+  "version": "0.1.1-beta.0",
   "description": "React bindings for URL data",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/PromiseState.js
+++ b/src/PromiseState.js
@@ -1,5 +1,6 @@
-export default function PromiseState({ pending = false, fulfilled = false, rejected = false, value = null, reason = null }) {
+export default function PromiseState({ pending = false, refreshing = false, fulfilled = false, rejected = false, value = null, reason = null }) {
   this.pending = pending
+  this.refreshing = refreshing
   this.fulfilled = fulfilled
   this.rejected = rejected
   this.settled = fulfilled || rejected

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -2,7 +2,6 @@ import 'whatwg-fetch'
 import React, { Component } from 'react'
 import isPlainObject from '../utils/isPlainObject'
 import deepValue from '../utils/deepValue'
-import shallowEqual from '../utils/shallowEqual'
 import PromiseState from '../PromiseState'
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant'
@@ -122,8 +121,8 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
         Object.keys(nextMappings).forEach(prop => {
           const prev = this.state.mappings[prop]
           const next = nextMappings[prop]
-          const comp = [ 'request.url', 'request.method', 'request.headers' ]
-          const same = comp.every(c => shallowEqual(deepValue(prev, c), deepValue(next, c)))
+          const comp = [ 'request.url', 'request.method' ]
+          const same = comp.every(c => deepValue(prev, c) === deepValue(next, c))
 
           if (!same) {
             this.refetchDatum(prop, next, false)

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -126,6 +126,8 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
 
           if (!same) {
             this.refetchDatum(prop, next, false)
+          } else if (prev.refreshInterval !== next.refreshInterval) {
+            this.refetchDatum(prop, next, true)
           }
         })
       }

--- a/src/utils/deepValue.js
+++ b/src/utils/deepValue.js
@@ -1,0 +1,9 @@
+export default function deepValue(obj, path) {
+  for (let i = 0, spath = path.split('.'), len = spath.length; i < len; i++) {
+    if (obj === undefined) {
+      return obj
+    }
+    obj = obj[spath[i]]
+  }
+  return obj
+}

--- a/src/utils/shallowEqual.js
+++ b/src/utils/shallowEqual.js
@@ -3,6 +3,10 @@ export default function shallowEqual(objA, objB) {
     return true
   }
 
+  if (objA || objB) {
+    return false
+  }
+
   const keysA = Object.keys(objA)
   const keysB = Object.keys(objB)
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -60,7 +60,7 @@ describe('React', () => {
     })
 
     it('should set startedAt', (done) => {
-      @connect(({ foo, baz }) => ({ testFetch: `/example` }))
+      @connect(() => ({ testFetch: `/example` }))
       class Container extends Component {
         render() {
           return <Passthrough {...this.props} />
@@ -72,7 +72,7 @@ describe('React', () => {
       )
 
       const pending = TestUtils.findRenderedComponentWithType(container, Container)
-      var startedAt = pending.state.startedAts.testFetch
+      const startedAt = pending.state.startedAts.testFetch
       expect(startedAt.getTime()).toBeLessThan(new Date().getTime())
       setImmediate(() => {
         const fulfilled = TestUtils.findRenderedComponentWithType(container, Container)

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -30,12 +30,6 @@ describe('React', () => {
         <Container {...props} />
       )
 
-      const decorated = TestUtils.findRenderedComponentWithType(container, Container)
-      expect(decorated.state.requests.testFetch.method).toEqual('GET')
-      expect(decorated.state.requests.testFetch.url).toEqual('/bar/42')
-      expect(decorated.state.requests.testFetch.credentials).toEqual('same-origin')
-      expect(decorated.state.data.testFetch).toEqual({ fulfilled: false, pending: true, reason: null, rejected: false, settled: false, value: null })
-
       const stub = TestUtils.findRenderedComponentWithType(container, Passthrough)
       expect(stub.props.foo).toEqual('bar')
       expect(stub.props.baz).toEqual(42)
@@ -44,6 +38,85 @@ describe('React', () => {
       expect(() =>
         TestUtils.findRenderedComponentWithType(container, Container)
       ).toNotThrow()
+    })
+
+    it('should create default Request and empty options if just URL is provided', () => {
+      @connect(() => ({ testFetch: `/example` }))
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      const container = TestUtils.renderIntoDocument(
+        <Container />
+      )
+
+      const decorated = TestUtils.findRenderedComponentWithType(container, Container)
+      expect(decorated.state.mappings.testFetch.request.method).toEqual('GET')
+      expect(decorated.state.mappings.testFetch.request.url).toEqual('/example')
+      expect(decorated.state.mappings.testFetch.request.credentials).toEqual('same-origin')
+    })
+
+    it('should use provided Request with empty options if custom Request is provided', () => {
+      @connect(() => ({ testFetch: new window.Request('/example', { method: 'POST' })}))
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      const container = TestUtils.renderIntoDocument(
+        <Container />
+      )
+
+      const decorated = TestUtils.findRenderedComponentWithType(container, Container)
+      expect(Object.keys(decorated.state.mappings.testFetch).length).toEqual(1)
+      expect(decorated.state.mappings.testFetch.request.method).toEqual('POST')
+      expect(decorated.state.mappings.testFetch.request.url).toEqual('/example')
+      expect(decorated.state.mappings.testFetch.request.credentials).toEqual('omit')
+    })
+
+    it('should create default Request with provided options if custom options are provided', () => {
+      @connect(() => ({ testFetch: [`/example`, { anOption: true, anotherOption: 'blue' }] }))
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      const container = TestUtils.renderIntoDocument(
+        <Container />
+      )
+
+      const decorated = TestUtils.findRenderedComponentWithType(container, Container)
+      expect(Object.keys(decorated.state.mappings.testFetch).length).toEqual(3)
+      expect(decorated.state.mappings.testFetch.request.method).toEqual('GET')
+      expect(decorated.state.mappings.testFetch.request.url).toEqual('/example')
+      expect(decorated.state.mappings.testFetch.request.credentials).toEqual('same-origin')
+      expect(decorated.state.mappings.testFetch.anOption).toEqual(true)
+      expect(decorated.state.mappings.testFetch.anotherOption).toEqual('blue')
+    })
+
+    it('should use provided Request with provided options if custom Request and options are provided', () => {
+      @connect(() => ({ testFetch: [new window.Request(`/example`), { anOption: true, anotherOption: 'blue' }] }))
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      const container = TestUtils.renderIntoDocument(
+        <Container />
+      )
+
+      const decorated = TestUtils.findRenderedComponentWithType(container, Container)
+      expect(Object.keys(decorated.state.mappings.testFetch).length).toEqual(3)
+      expect(decorated.state.mappings.testFetch.request.method).toEqual('GET')
+      expect(decorated.state.mappings.testFetch.request.url).toEqual('/example')
+      expect(decorated.state.mappings.testFetch.request.credentials).toEqual('omit')
+      expect(decorated.state.mappings.testFetch.anOption).toEqual(true)
+      expect(decorated.state.mappings.testFetch.anotherOption).toEqual('blue')
     })
 
     it('should remove undefined props', () => {

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -59,6 +59,28 @@ describe('React', () => {
       })
     })
 
+    it('should set startedAt', (done) => {
+      @connect(({ foo, baz }) => ({ testFetch: `/example` }))
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      const container = TestUtils.renderIntoDocument(
+        <Container />
+      )
+
+      const pending = TestUtils.findRenderedComponentWithType(container, Container)
+      var startedAt = pending.state.startedAts.testFetch
+      expect(startedAt.getTime()).toBeLessThan(new Date().getTime())
+      setImmediate(() => {
+        const fulfilled = TestUtils.findRenderedComponentWithType(container, Container)
+        expect(fulfilled.state.startedAts.testFetch).toEqual(startedAt)
+        done()
+      })
+    })
+
     it('should create default Request and empty options if just URL is provided', () => {
       @connect(() => ({ testFetch: `/example` }))
       class Container extends Component {

--- a/test/utils/deepValue.spec.js
+++ b/test/utils/deepValue.spec.js
@@ -1,0 +1,12 @@
+import expect from 'expect'
+import deepValue from '../../src/utils/deepValue'
+
+describe('Utils', () => {
+  describe('deepValue', () => {
+    it('find deep value of nested objects', () => {
+      expect(deepValue({ x: 1 }, 'x')).toBe(1)
+      expect(deepValue({ x: { y: 2 } }, 'x.y')).toBe(2)
+      expect(deepValue({ x: { y: 2 } }, 'x.y.z')).toBe(undefined)
+    })
+  })
+})


### PR DESCRIPTION
This adds a new option to be able to refresh data on a given interval. Explanation from readme:

If the`refreshInterval` option is provided with a URL, the data will be refreshed at the provided interval in milliseconds. In this example, `likesFetch` will be refreshed every minute:

    connect(props => {
     return {
       userFetch:  `/users/${props.userId}`,
       likesFetch: [`/likes/${props.userId}/likes`, { refreshInterval: 60000 }]
     }
    })(Profile)
 
When refreshing, the `PromiseState` will be `refreshing`, `pending` will be `false`, and its `value` will still be set to the previously fulfilled value.

cc: @jsullivan @ricardochimal 