### PR TITLE
Add and use methods to PromiseState for parity with Promise

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -63,6 +63,21 @@ Properties should be treated as read-only and immutable. If the `Promise` enters
 
 ##### Static Methods
 
+##### `create(meta): PromiseState`
+
+##### `refresh(previous: PromiseState, meta): PromiseState`
+
+##### `resolve(value, meta): PromiseState`
+
+##### `reject(value, meta): PromiseState`
+
+##### `race(iterable<PromiseState>): PromiseState`
+
 ##### `all(iterable<PromiseState>): PromiseState`
 
-Similar to [`PromiseState.all()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/all), this method composes an iterable, such as an `Array`, of `PromiseState`s into a single `PromiseState`. The combined `PromiseState` will only be `fulfilled` when all the `PromiseState`s are `fulfilled` and the `value` will be an iterable of the composite values. If any of the `PromiseState`s are `rejected`, the `reason` of the first rejected `PromiseState` will be set.
+
+##### Instance Methods
+
+###### `then(onFulfilled: Function, onRejected: Function): PromiseState`
+
+###### `catch(onRejected: Function): PromiseState`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-refetch",
-  "version": "0.3.0",
+  "version": "0.4.0-beta.0",
   "description": "React bindings for URL data",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/PromiseState.js
+++ b/src/PromiseState.js
@@ -1,5 +1,39 @@
 export default class PromiseState {
 
+  // creates a new PromiseState that is pending
+  static create(meta) {
+    return new PromiseState({
+      pending: true,
+      meta: meta
+    })
+  }
+
+  // creates as PromiseState that is refreshing
+  // can be called without a previous PromiseState and will be both pending and refreshing
+  static refresh(previous, meta) {
+    const ps = previous || PromiseState.create(meta)
+    ps.refreshing = true
+    return ps
+  }
+
+  // creates a PromiseState that is resolved with the given value
+  static resolve(value, meta) {
+    return new PromiseState({
+      fulfilled: true,
+      value: value,
+      meta: meta
+    })
+  }
+
+  // creates a PromiseState that is rejected with the given reason
+  static reject(reason, meta) {
+    return new PromiseState({
+      rejected: true,
+      reason: reason,
+      meta: meta
+    })
+  }
+
   // The PromiseState.all(iterable) method returns a PromiseState
   // that resolves when all of the PromiseStates in the iterable
   // argument have resolved, or rejects with the reason of the
@@ -16,6 +50,25 @@ export default class PromiseState {
     })
   }
 
+  // The PromiseState.race(iterable) method returns a PromiseState
+  // that resolves or rejects as soon as one of the PromiseStates in
+  // the iterable resolves or rejects, with the value or reason
+  // from that PromiseState.
+  static race(iterable) {
+    const winner = iterable.find(ps => ps.settled)
+
+    return new PromiseState({
+      pending: !winner && iterable.some(ps => ps.pending),
+      refreshing: !winner && iterable.some(ps => ps.refreshing),
+      fulfilled: winner && winner.fulfilled,
+      rejected: winner && winner.rejected,
+      value: winner && winner.value,
+      reason: winner && winner.reason,
+      meta: winner && winner.meta
+    })
+  }
+
+  // Constructor for creating a raw PromiseState. DO NOT USE DIRECTLY. Instead, use PromiseState.create() or other static constructors
   constructor({ pending = false, refreshing = false, fulfilled = false, rejected = false, value = null, reason = null, meta = {} }) {
     this.pending = pending
     this.refreshing = refreshing
@@ -25,5 +78,39 @@ export default class PromiseState {
     this.value = value
     this.reason = reason
     this.meta = meta
+  }
+
+  // Appends and calls fulfillment and rejection handlers on the PromiseState,
+  // and returns a new PromiseState resolving to the return value of the called handler,
+  // or to its original settled value if the promise was not handled
+  // (i.e. if the relevant handler onFulfilled or onRejected is undefined).
+  // Note, unlike Promise.then(), these handlers are called immediately.
+  then(onFulFilled, onRejected) {
+    if (this.fulfilled && onFulFilled) {
+      return this._mapFlatMapValue(onFulFilled(this.value))
+    }
+
+    if (this.rejected && onRejected) {
+      return this._mapFlatMapValue(onRejected(this.reason))
+    }
+
+    return this
+  }
+
+  // Appends and calls a rejection handler callback to the PromiseState,
+  // and returns a new PromiseState resolving to the return value of the
+  // callback if it is called, or to its original fulfillment value if
+  // the PromiseState is instead fulfilled. Note, unlike Promise.catch(),
+  // this handlers is called immediately.
+  catch(onRejected) {
+    return this.then(undefined, onRejected)
+  }
+
+  _mapFlatMapValue(value) {
+    if (value instanceof PromiseState) {
+      return value
+    } else {
+      return PromiseState.resolve(value, this.meta)
+    }
   }
 }

--- a/test/PromiseState.spec.js
+++ b/test/PromiseState.spec.js
@@ -2,6 +2,80 @@ import expect from 'expect'
 import PromiseState from '../src/PromiseState'
 
 describe('PromiseState', () => {
+
+  const onFulFilled = (v) => `F[${v}]`
+  const onRejected  = (r) => `R[${r}]`
+
+  const onFulFilledToPromiseState = (v) => PromiseState.resolve(`F[${v}]`)
+  const onRejectedToPromiseState  = (r) => PromiseState.resolve(`R[${r}]`)
+
+  describe('then', () => {
+    it('pending', () => {
+      const ps = PromiseState.create().then(onFulFilled, onRejected)
+      expect(ps.pending).toBe(true)
+      expect(ps.value).toBe(null)
+    })
+
+    it('fulfilled (undefined)', () => {
+      const ps = PromiseState.resolve('v').then(undefined, undefined)
+      expect(ps.pending).toBe(false)
+      expect(ps.fulfilled).toBe(true)
+      expect(ps.value).toBe('v')
+    })
+
+    it('fulfilled (map)', () => {
+      const ps = PromiseState.resolve('v').then(onFulFilled, onRejected)
+      expect(ps.pending).toBe(false)
+      expect(ps.fulfilled).toBe(true)
+      expect(ps.value).toBe('F[v]')
+    })
+
+    it('fulfilled (flatMap)', () => {
+      const ps = PromiseState.resolve('v').then(onFulFilledToPromiseState, onRejectedToPromiseState)
+      expect(ps.pending).toBe(false)
+      expect(ps.fulfilled).toBe(true)
+      expect(ps.value).toBe('F[v]')
+    })
+
+    it('rejected', () => {
+      const ps = PromiseState.reject('r').then(onFulFilled, onRejected)
+      expect(ps.pending).toBe(false)
+      expect(ps.fulfilled).toBe(true)
+      expect(ps.rejected).toBe(false)
+      expect(ps.value).toBe('R[r]')
+      expect(ps.reason).toBe(null)
+    })
+
+    it('rejected (chained)', () => {
+      const ps = PromiseState.reject('r').then(onFulFilled, onRejected).then(onFulFilled, onRejected)
+      expect(ps.pending).toBe(false)
+      expect(ps.fulfilled).toBe(true)
+      expect(ps.rejected).toBe(false)
+      expect(ps.value).toBe('F[R[r]]')
+      expect(ps.reason).toBe(null)
+    })
+  })
+
+  describe('catch', () => {
+    it('pending', () => {
+      const ps = PromiseState.create().catch(onRejected)
+      expect(ps.pending).toBe(true)
+      expect(ps.value).toBe(null)
+    })
+
+    it('fulfilled', () => {
+      const ps = PromiseState.resolve('v').catch(onRejected)
+      expect(ps.pending).toBe(false)
+      expect(ps.value).toBe('v')
+    })
+
+    it('rejected', () => {
+      const ps = PromiseState.reject('r').catch(onRejected)
+      expect(ps.pending).toBe(false)
+      expect(ps.value).toBe('R[r]')
+    })
+  })
+
   describe('all', () => {
     it('pending', () => {
       expect(PromiseState.all([
@@ -31,7 +105,7 @@ describe('PromiseState', () => {
       expect(PromiseState.all([
         new PromiseState({ fulfilled: true }),
         new PromiseState({ fulfilled: false })
-      ]).refreshing).toBe(false)
+      ]).fulfilled).toBe(false)
 
       expect(PromiseState.all([
         new PromiseState({ fulfilled: true }),
@@ -64,6 +138,91 @@ describe('PromiseState', () => {
         new PromiseState({ meta: 'A' }),
         new PromiseState({ meta: 'B' })
       ]).meta).toEqual([ 'A', 'B' ])
+    })
+  })
+  
+  describe('race', () => {
+    it('pending', () => {
+      expect(PromiseState.race([
+        new PromiseState({ pending: true }),
+        new PromiseState({ pending: false })
+      ]).pending).toBe(true)
+      
+      expect(PromiseState.race([
+        new PromiseState({ pending: false }),
+        new PromiseState({ pending: false })
+      ]).pending).toBe(false)
+    })
+
+    it('refreshing', () => {
+      expect(PromiseState.race([
+        new PromiseState({ refreshing: true }),
+        new PromiseState({ refreshing: false })
+      ]).refreshing).toBe(true)
+
+      expect(PromiseState.race([
+        new PromiseState({ refreshing: false }),
+        new PromiseState({ refreshing: false })
+      ]).refreshing).toBe(false)
+    })
+
+    it('fulfilled', () => {
+      expect(PromiseState.race([
+        new PromiseState({ fulfilled: false }),
+        new PromiseState({ fulfilled: false })
+      ]).fulfilled).toBe(false)
+
+      expect(PromiseState.race([
+        new PromiseState({ fulfilled: true }),
+        new PromiseState({ fulfilled: false })
+      ]).fulfilled).toBe(true)
+
+      expect(PromiseState.race([
+        new PromiseState({ fulfilled: true }),
+        new PromiseState({ fulfilled: true })
+      ]).fulfilled).toBe(true)
+    })
+
+    it('value', () => {
+      expect(PromiseState.race([
+        new PromiseState({ fulfilled: true, value: 'A' }),
+        new PromiseState({ fulfilled: true, value: 'B' })
+      ]).value).toEqual('A')
+
+      expect(PromiseState.race([
+        new PromiseState({ fulfilled: false }),
+        new PromiseState({ fulfilled: true, value: 'B' })
+      ]).value).toEqual('B')
+
+      expect(PromiseState.race([
+        new PromiseState({ fulfilled: false }),
+        new PromiseState({ fulfilled: false })
+      ]).value).toEqual(null)
+    })
+
+    it('reason', () => {
+      expect(PromiseState.race([
+        new PromiseState({ rejected: false }),
+        new PromiseState({ rejected: true, reason: 'B' }),
+        new PromiseState({ rejected: true, reason: 'C' })
+      ]).reason).toEqual('B')
+
+      expect(PromiseState.race([
+        new PromiseState({ rejected: false }),
+        new PromiseState({ rejected: false })
+      ]).reason).toEqual(null)
+    })
+
+    it('meta', () => {
+      expect(PromiseState.race([
+        new PromiseState({ meta: 'A' }),
+        new PromiseState({ meta: 'B' })
+      ]).meta).toEqual({})
+
+      expect(PromiseState.race([
+        new PromiseState({ meta: 'A' }),
+        new PromiseState({ fulfilled: true, meta: 'B' })
+      ]).meta).toEqual('B')
     })
   })
 })


### PR DESCRIPTION
I added the remaining methods to `PromiseState` for parity with `Promise`. I did this because I needed to error handle a `PromiseState` that was part of a composition, and this made it clean use with `catch()` as it were an actual `Promise`.

For example, sometimes `statusesFetch` will fail, but this recovers the error and sets the value to `[]` and makes it still work with `PromiseState.all()` (I would not have been able to recover inside `AlarmTable` because the composition would have never been fulfilled):

```
render() {
    const { alarmsFetch, statusesFetch } = this.props

    return (
      <PromiseStateContainer
        ps={PromiseState.all([alarmsFetch, statusesFetch.catch(() => [])])}
        onFulfillment={([alarms, statuses]) => <AlarmTable alarms={alarms} statuses={statuses}/>}
      />
    )
  }
``` 

cc: @jsullivan @ricardochimal 