### PR TITLE
Chainable requests

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -11,15 +11,19 @@ Instead, it *returns* a new, connected component class, for you to use.
 
 * [`mapPropsToRequestsToProps(props): { prop: request, ... }`] *(Function)*: A pure function of props that specifies the requests to fetch data and the props to which to assign the results. This function is called every time props change, and if the requests materially change, the data will be refetched. Requests can be specified as plain URL strings, request objects, or functions. Plain URL strings are the most common and preferred format, but only support GET URLs with default options. For more advanced options, specify the request as an object the the following keys:
 
- - `url` *(String)*: Required. HTTP URL from which to fetch the data.
- - `method` *(String)*: HTTP method. Defaults to `GET`.
- - `headers` *(Object)*: HTTP headers as simple key-value pairs. Defaults to `Accept` and `Content-Type` set to `application/json`.
- - `credentials` *(String)*: Policy for credential to include with request. One of `omit`, `same-origin`, `include`. Defaults to `same-origin`. See [`Request.credentials`](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) for details.
- - `body`: Any body that you want to add to your request; however, it must be replayable (i.e. not a one time use stream). Note that a request using the `GET` or `HEAD` method cannot have a body.
- - `refreshInterval` *(Integer)*: Interval in milliseconds to poll for new data from the URL.
- - `refreshing` *(Boolean)*: If true, the request is treated as a refresh. This is generally only used when overwriting an existing `PromiseState` and it is desired that the existing `value` not be cleared or changing into the `pending` state while the request is in flight. If no previous request was fulfilled, both `pending` and `refreshing` will be set.
- - `force` *(Boolean)*: Forces the data to be always fetched when new props are received. Takes precedence over `comparison`.
- - `comparison` *(Any)*: Custom value for comparing this request and the previous request when the props change. If the `comparison` values are *not* strictly equal, the data will be fetched again. In general, it is preferred to rely on the default that compares material changes to the request (i.e. URL, headers, body, etc); however, this is helpful in cases where the request should or should not be fetched again based on some other value. If `force` is true, `comparison` is not considered.
+     - `url` *(String)*: Required. HTTP URL from which to fetch the data.
+     - `method` *(String)*: HTTP method. Defaults to `GET`.
+     - `headers` *(Object)*: HTTP headers as simple key-value pairs. Defaults to `Accept` and `Content-Type` set to `application/json`.
+     - `credentials` *(String)*: Policy for credential to include with request. One of `omit`, `same-origin`, `include`. Defaults to `same-origin`. See [`Request.credentials`](https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials) for details.
+     - `body`: Any body that you want to add to your request; however, it must be replayable (i.e. not a one time use stream). Note that a request using the `GET` or `HEAD` method cannot have a body.
+     - `refreshInterval` *(Integer)*: Interval in milliseconds to poll for new data from the URL.
+     - `refreshing` *(Boolean)*: If true, the request is treated as a refresh. This is generally only used when overwriting an existing `PromiseState` and it is desired that the existing `value` not be cleared or changing into the `pending` state while the request is in flight. If no previous request was fulfilled, both `pending` and `refreshing` will be set.
+     - `force` *(Boolean)*: Forces the data to be always fetched when new props are received. Takes precedence over `comparison`.
+     - `comparison` *(Any)*: Custom value for comparing this request and the previous request when the props change. If the `comparison` values are *not* strictly equal, the data will be fetched again. In general, it is preferred to rely on the default that compares material changes to the request (i.e. URL, headers, body, etc); however, this is helpful in cases where the request should or should not be fetched again based on some other value. If `force` is true, `comparison` is not considered.
+      - `then(value, meta): request` *(Function)*: returns a request to fetch after fulfillment of this request and replaces this request. Takes the `value` and `meta` of this request as arguments.
+      - `catch(reason, meta): request` *(Function)*: returns a request to fetch after rejection of this request and replaces this request. Takes the `value` and `meta` of this request as arguments.
+      - `andThen(value, meta): { prop: request, ... }` *(Function)*: returns an object of request mappings to fetch after fulfillment of this request but does not replace this request. Takes the `value` and `meta` of this request as arguments.
+      - `andCatch(reason, meta): { prop: request, ... }` *(Function)*: returns an object of request mappings to fetch after rejection of this request but does not replace this request. Takes the `value` and `meta` of this request as arguments.
 
 Requests specified as functions are not fetched immediately when props are received, but rather bound to the props and injected into the component to be called at a later time in response to user actions. Functions should be pure and return the same format as `mapPropsToRequestsToProps` itself. If a function maps a request to the same name as an existing prop, the prop will be overwritten. This is commonly used for taking some action that updates an existing `PromiseState`. Consider setting `refreshing: true` in such it situation. 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-refetch",
-  "version": "0.5.0-beta.0",
+  "version": "0.5.0-beta.1",
   "description": "A simple, declarative, and composable way to fetch data for React components.",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-refetch",
-  "version": "0.4.2",
+  "version": "0.5.0-beta.0",
   "description": "A simple, declarative, and composable way to fetch data for React components.",
   "main": "./lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-refetch",
-  "version": "0.5.0-beta.1",
+  "version": "0.5.0",
   "description": "A simple, declarative, and composable way to fetch data for React components.",
   "main": "./lib/index.js",
   "scripts": {

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -174,8 +174,6 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
               }, mapping.refreshInterval)
             }
 
-            // TODO: re-think naming and params of then, catch, andThen, andCatch
-
             if (Function.prototype.isPrototypeOf(mapping.then)) {
               this.refetchDatum(prop, coerceMapping(null, mapping.then(value, meta)))
               return

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -174,15 +174,27 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
               }, mapping.refreshInterval)
             }
 
+            // TODO: re-think naming and params of then, catch, andThen, andCatch
+
+            if (Function.prototype.isPrototypeOf(mapping.then)) {
+              this.refetchDatum(prop, coerceMapping(null, mapping.then(value, meta)))
+              return
+            }
+
             this.setAtomicState(prop, startedAt, mapping, PromiseState.resolve(value, meta), refreshTimeout, () => {
-              if (Function.prototype.isPrototypeOf(mapping.then)) {
-                this.refetchDataFromMappings(mapping.then(value, meta))
+              if (Function.prototype.isPrototypeOf(mapping.andThen)) {
+                this.refetchDataFromMappings(mapping.andThen(value, meta))
               }
             })
           }).catch(reason => {
+            if (Function.prototype.isPrototypeOf(mapping.catch)) {
+              this.refetchDatum(coerceMapping(null, mapping.catch(reason, meta)))
+              return
+            }
+
             this.setAtomicState(prop, startedAt, mapping, PromiseState.reject(reason, meta), null, () => {
-              if (Function.prototype.isPrototypeOf(mapping.catch)) {
-                this.refetchDataFromMappings(mapping.catch(reason, meta))
+              if (Function.prototype.isPrototypeOf(mapping.andCatch)) {
+                this.refetchDataFromMappings(mapping.andCatch(reason, meta))
               }
             })
           })

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -53,7 +53,7 @@ describe('React', () => {
       expect(stubPending.props.testFetch.constructor).toEqual(PromiseState)
 
       expect(stubPending.props.testFunc).toBeA('function')
-      expect(stubPending.props.deferredFetch).toEqual(null)
+      expect(stubPending.props.deferredFetch).toEqual(undefined)
       stubPending.props.testFunc('A', 'B')
       expect(stubPending.props.deferredFetch).toIncludeKeyValues({
         fulfilled: false, pending: true, refreshing: false, reason: null, rejected: false, settled: false, value: null, meta: {}
@@ -181,7 +181,7 @@ describe('React', () => {
       const decorated = TestUtils.findRenderedComponentWithType(container, Container)
       expect(decorated.state.mappings.testFunc).toBeA('function')
       expect(decorated.state.data.testFunc).toBeA('function')
-      expect(decorated.state.data.deferredFetch).toEqual(null)
+      expect(decorated.state.data.deferredFetch).toEqual(undefined)
 
       decorated.state.data.testFunc('A', 'B')
 


### PR DESCRIPTION
This introduces four new attributes for chainable requests. I'm still not sure on the names and syntax, but here they are:

- `then(value, meta): request` *(Function)*: returns a request to fetch after fulfillment of this request and replaces this request. Takes the `value` and `meta` of this request as arguments.
- `catch(reason, meta): request` *(Function)*: returns a request to fetch after rejection of this request and replaces this request. Takes the `value` and `meta` of this request as arguments.
- `andThen(value, meta): { prop: request, ... }` *(Function)*: returns an object of request mappings to fetch after fulfillment of this request but does not replace this request. Takes the `value` and `meta` of this request as arguments.
- `andCatch(reason, meta): { prop: request, ... }` *(Function)*: returns an object of request mappings to fetch after rejection of this request but does not replace this request. Takes the `value` and `meta` of this request as arguments.

`then` is helpful for cases where multiple requests are needed to get to the data needed by the component and the subsequent requests rely on data from the previous requests. For example, if you need to make a request to look up a piece of data to perform some other operation:
 
      connect(({ name }) => ({
        barFetch: {
          url: `/foos/${name}`,
          then: (foo) => `/bar-for-foos-by-id/${foo.id}`
        }
      }))

`andThen` is similar, but is intended for side effect requests where you still need access to the result of the first request and/or need to fanout to multiple requests:

      connect(({ name }) => ({
        fooFetch: {
          url: `/foos/${name}`,
          andThen: (foo) => { 
            barFetch: `/bar-for-foos-by-id/${foo.id}` 
          }
        }
      }))

This is also helpful for cases where a fetch function is changing data that is in some other fetch that is a collection. For example, if you have a list of `foo`s and you create a new `foo`, the list needs to be refreshed:

     connect(({ name }) => ({
        foosFetch: '/foos',
        createFoo: (name) => {
           method: 'POST',
           url: '/foos',
           andThen: () => { 
             foosFetch: { 
               url: '/foos', 
               refreshing: true 
             }
           }
        }
      }))

`catch` and `andCatch` are similar, but for error cases.

Feedback is welcome on the naming of these attributes. Are they clear what they do and how they work?

cc: @jsullivan @ricardochimal 