### PR TITLE
Make it possible to disable auto refresh while browser tab is hidden

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ connect(props => ({
 
 When refreshing, the `PromiseState` will be the same as a the previous `fulfilled` state, but with the `refreshing` attribute set. That is, `pending` will remain unset and the existing `value` will be left in tact. When the refresh completes, `refreshing` will be unset and the `value` will be updated with the latest data. If the refresh is rejected, the `PromiseState` will move into a `rejected` and not attempt to refresh again.
 
+If the `refreshHidden` options is provided with `false` value the automatic refresh will be disabled while the browser tab is hidden. `refreshHidden` is `true` by default.
+
 ## Fetch Functions
 
 Instead of mapping the props directly to a URL string or request object, you can also map the props to a function that returns a URL string or request object. When the component receives props, instead of the data being fetched immediately and injected as a `PromiseState`, the function is bound to the props and injected into the component as functional prop to be called later (usually in response to a user action). This can be used to either lazy load data, post data to the server, or refresh data. These are best shown with examples:

--- a/package.json
+++ b/package.json
@@ -51,10 +51,12 @@
     "react-addons-test-utils": "^0.14.0",
     "react-dom": "^0.14.0",
     "rimraf": "^2.3.4",
+    "sinon": "^1.17.2",
     "webpack": "^1.11.0"
   },
   "dependencies": {
     "hoist-non-react-statics": "^1.0.3",
+    "visibilityjs": "^1.2.1",
     "invariant": "^2.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
- [x] provide `refreshHidden` option to disable bg refresh while tab is hidden

Pooling the server while tab is hidden is usually wrong: unnecessary load on servers, bandwitch usage and battery draining on the client.
