### PR TITLE
Apply defaults during coercion to consider for equality

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -49,6 +49,8 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
     invariant(isPlainObject(mapping), 'Request for `%s` must be either a string or a plain object. Instead received %s', prop, mapping)
     invariant(mapping.url, 'Request object for `%s` must have `url` attribute.', prop)
 
+    mapping = assignDefaults(mapping)
+
     mapping.equals = function (that) {
       if (this.comparison !== undefined) {
         return this.comparison === that.comparison
@@ -62,15 +64,32 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
     return mapping
   }
 
+  function assignDefaults(mapping) {
+    return Object.assign(
+      {
+        method: 'GET',
+        credentials: 'same-origin',
+        redirect: 'follow'
+      },
+      mapping,
+      {
+        headers: Object.assign(
+          {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json'
+          },
+          mapping.headers
+        )
+      }
+    )
+  }
+
   function buildRequest(mapping) {
     return new window.Request(mapping.url, {
-      method: mapping.method || 'GET',
-      headers: Object.assign({
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
-      }, mapping.headers),
-      credentials: mapping.credentials || 'same-origin',
-      redirect: mapping.redirect || 'follow',
+      method: mapping.method,
+      headers: mapping.headers,
+      credentials: mapping.credentials,
+      redirect: mapping.redirect,
       body: mapping.body
     })
   }

--- a/src/utils/shallowEqual.js
+++ b/src/utils/shallowEqual.js
@@ -3,7 +3,7 @@ export default function shallowEqual(objA, objB) {
     return true
   }
 
-  if (objA || objB) {
+  if (objA === undefined || objB === undefined) {
     return false
   }
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -139,8 +139,8 @@ describe('React', () => {
       expect(decorated.state.mappings.testFetch.url).toEqual('/example')
     })
 
-    it('should use provided mapping object', () => {
-      @connect(() => ({ testFetch: { url: '/example', method: 'POST' } }))
+    it('should use provided mapping object with applied defaults', () => {
+      @connect(() => ({ testFetch: { url: '/example', method: 'POST', headers: { 'Content-Type': 'overwrite-default', 'X-Foo': 'custom-foo' } } }))
       class Container extends Component {
         render() {
           return <Passthrough {...this.props} />
@@ -152,9 +152,13 @@ describe('React', () => {
       )
 
       const decorated = TestUtils.findRenderedComponentWithType(container, Container)
-      expect(Object.keys(decorated.state.mappings.testFetch).length).toEqual(3)
+      expect(Object.keys(decorated.state.mappings.testFetch).length).toEqual(6)
       expect(decorated.state.mappings.testFetch.method).toEqual('POST')
+      expect(decorated.state.mappings.testFetch.headers).toEqual({ Accept: 'application/json', 'Content-Type': 'overwrite-default', 'X-Foo': 'custom-foo' })
+      expect(decorated.state.mappings.testFetch.credentials).toEqual('same-origin')
+      expect(decorated.state.mappings.testFetch.redirect).toEqual('follow')
       expect(decorated.state.mappings.testFetch.url).toEqual('/example')
+      expect(decorated.state.mappings.testFetch.equals).toBeA('function')
     })
 
     it('should allow functional mappings', () => {

--- a/test/utils/shallowEqual.spec.js
+++ b/test/utils/shallowEqual.spec.js
@@ -1,0 +1,57 @@
+import expect from 'expect'
+import shallowEqual from '../../src/utils/shallowEqual'
+
+describe('Utils', () => {
+  describe('shallowEqual', () => {
+    it('should return true if arguments fields are equal', () => {
+      expect(
+        shallowEqual(
+          { a: 1, b: 2, c: undefined },
+          { a: 1, b: 2, c: undefined }
+        )
+      ).toBe(true)
+
+      expect(
+        shallowEqual(
+          { a: 1, b: 2, c: 3 },
+          { a: 1, b: 2, c: 3 }
+        )
+      ).toBe(true)
+
+      const o = {}
+      expect(
+        shallowEqual(
+          { a: 1, b: 2, c: o },
+          { a: 1, b: 2, c: o }
+        )
+      ).toBe(true)
+    })
+
+    it('should return false if first argument has too many keys', () => {
+      expect(
+        shallowEqual(
+          { a: 1, b: 2, c: 3 },
+          { a: 1, b: 2 }
+        )
+      ).toBe(false)
+    })
+
+    it('should return false if second argument has too many keys', () => {
+      expect(
+        shallowEqual(
+          { a: 1, b: 2 },
+          { a: 1, b: 2, c: 3 }
+        )
+      ).toBe(false)
+    })
+
+    it('should return false if arguments have different keys', () => {
+      expect(
+        shallowEqual(
+          { a: 1, b: 2, c: undefined },
+          { a: 1, bb: 2, c: undefined }
+        )
+      ).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
This moves the application of defaults out of `buildRequest()` and into a separate function that is called during request coercion. This allows the defaults to be considered for equality so that implicit and explicit request attributes are treated the same and fixes #31.

As part of fixing this, I realized that the `shallowEquals()` was broken for objects (became apparent once default headers were considered) and was missing tests. Somehow these got dropped in the fork from react-redux. This also fixes this issue.

cc: 
 - @jwdotjs: I confirmed this fixed your issue
 - @hekike: You may wish to rebase https://github.com/heroku/react-refetch/pull/23 on this and do your default handing in `applyDefaults()`
 - @jsullivan