### PR TITLE
Add Support for Identity Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,44 @@ This is also helpful for cases where a fetch function is changing data that is i
 
 `catch` and `andCatch` are similar, but for error cases.
 
+## Identity Requests: Static Data & Transforming Responses
+
+To support static data and response transformations, there is a special kind of request called an "identity request" that has a `value` instead of a `url`. The `value` is passed through directly to the `PromiseState` without actually fetching anything. In its pure form, it looks like this:
+
+```jsx
+connect(props => ({
+  usersFetch: {
+    value: [
+      {
+        id: 1,
+        name: 'Jane Doe',
+        verified: true
+      },
+      {
+        id: 2,
+        name: 'John Doe',
+        verified: false
+      }
+    ]
+  }
+}))(Users)
+```
+
+In this case the `userFetch` `PromiseState` will be set to the provided list of users. The use case for identity requests by themselves is limited to mostly injecting static data during development and testing; however, they can be quite powerful when used with [request chaining](#chaining-requests). For example, it is possible to fetch data from the server, filter it within a `then` function, and return an identity request:
+
+```jsx
+connect(props => ({
+  usersFetch: {
+    url: `/users`,
+    then: (users) => ({
+      value: users.filter(u => u.verified)
+    })
+  }
+}))(Users)
+```
+
+Note, this form of transformation is similar to what is possible on the `PromiseState` (i.e. `this.props.usersFetch.then(users => users.filter(u => u.verified))`); however, this has the advantage of only being called when `usersFetch` changes and keeps the logic out of the component. 
+
 ## Accessing Headers & Metadata
 
 Both request and response headers and other metadata are accessible. Custom request headers can be set on the request as an object:

--- a/docs/api.md
+++ b/docs/api.md
@@ -25,6 +25,7 @@ Instead, it *returns* a new, connected component class, for you to use.
      - `catch(reason, meta): request` *(Function)*: returns a request to fetch after rejection of this request and replaces this request. Takes the `value` and `meta` of this request as arguments.
      - `andThen(value, meta): { prop: request, ... }` *(Function)*: returns an object of request mappings to fetch after fulfillment of this request but does not replace this request. Takes the `value` and `meta` of this request as arguments.
      - `andCatch(reason, meta): { prop: request, ... }` *(Function)*: returns an object of request mappings to fetch after rejection of this request but does not replace this request. Takes the `value` and `meta` of this request as arguments.
+     - `value` *(Any)*: Data to passthrough directly to `PromiseState` as an alternative to providing a URL. This is an advanced option used for static data and data transformations. 
 
 Requests specified as functions are not fetched immediately when props are received, but rather bound to the props and injected into the component to be called at a later time in response to user actions. Functions should be pure and return the same format as `mapPropsToRequestsToProps` itself. If a function maps a request to the same name as an existing prop, the prop will be overwritten. This is commonly used for taking some action that updates an existing `PromiseState`. Consider setting `refreshing: true` in such it situation. 
 

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -218,7 +218,7 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
         return (meta) => {
           return (reason) => {
             if (Function.prototype.isPrototypeOf(mapping.catch)) {
-              this.refetchDatum(coerceMapping(null, mapping.catch(reason, meta)))
+              this.refetchDatum(prop, coerceMapping(null, mapping.catch(reason, meta)))
               return
             }
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -169,6 +169,14 @@ describe('React', () => {
         <Container />
       )
 
+      const decorated = TestUtils.findRenderedComponentWithType(container, Container)
+      expect(decorated.state.mappings.testFetch.value).toEqual('foo')
+
+      const stub = TestUtils.findRenderedComponentWithType(container, Passthrough)
+      expect(stub.props.testFetch).toIncludeKeyValues({
+        fulfilled: false, pending: true, refreshing: false, reason: null, rejected: false, settled: false, value: null
+      })
+
       setImmediate(() => {
         const decorated = TestUtils.findRenderedComponentWithType(container, Container)
         expect(decorated.state.mappings.testFetch.value).toEqual('foo')


### PR DESCRIPTION
This implements "identity requests" as described in #33. See [Identity Requests: Static Data & Transforming Responses](https://github.com/heroku/react-refetch/blob/identity-requests/README.md#identity-requests-static-data--transforming-responses) for an explanation and example.

Note, this is not meant to handle the use case in #18 for post-processing (e.g. handling CSV responses) options. There is surely some overlap, but this is for transforming responses after any post-processing.

cc: @jsullivan @hburrows @georgebonnr @ashtuchkin @hnordt 