### PR TITLE
Add cause to errors to provide access to arbitrary fields

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -3,6 +3,7 @@ import React, { Component } from 'react'
 import isPlainObject from '../utils/isPlainObject'
 import deepValue from '../utils/deepValue'
 import shallowEqual from '../utils/shallowEqual'
+import newError from '../utils/errors'
 import PromiseState from '../PromiseState'
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant'
@@ -80,16 +81,7 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
     if (response.status >= 200 && response.status < 300) { // TODO: support custom acceptable statuses
       return json
     } else {
-      return json.then((errorJson) => {
-        const { id, error, message } = errorJson
-        if (error) {
-          throw new Error(error, id)
-        } else if (message) {
-          throw new Error(message, id)
-        } else {
-          throw new Error(errorJson)
-        }
-      })
+      return json.then(cause => Promise.reject(newError(cause)))
     }
   }
 

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -1,0 +1,17 @@
+export default function newError(cause) {
+  const e = new Error(parse(cause))
+  e.cause = cause
+  return e
+}
+
+function parse(cause) {
+  const { error, message } = cause
+
+  if (error) {
+    return error
+  } else if (message) {
+    return message
+  } else {
+    return ''
+  }
+}

--- a/test/utils/errors.spec.js
+++ b/test/utils/errors.spec.js
@@ -1,0 +1,24 @@
+import expect from 'expect'
+import newError from '../../src/utils/errors'
+
+describe('Utils', () => {
+  describe('newError', () => {
+    it('parses error with message', () => {
+      const e = newError({ message: 'm' })
+      expect(e.message).toBe('m')
+      expect(e.cause).toIncludeKeyValues({ message: 'm' })
+    })
+
+    it('parses error with error', () => {
+      const e = newError({ error: 'm' })
+      expect(e.message).toBe('m')
+      expect(e.cause).toIncludeKeyValues({ error: 'm' })
+    })
+
+    it('parses error without error or message to empty string ', () => {
+      const e = newError({ other: 'm' })
+      expect(e.message).toBe('')
+      expect(e.cause).toIncludeKeyValues({ other: 'm' })
+    })
+  })
+})


### PR DESCRIPTION
 - Replaces the (erroneous) `id` field on errors with the full error in a `cause` field
 - Returns the error as a rejection rather than a throw in the Promise
 - Replaces the unhelpful stringifiation of error with a `message` or `error` field to just an empty string
 - Adds error handling tests

Fixes #37 

cc: @jsullivan @imjoehaines