### PR TITLE
Passthrough provided meta in identity requests

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -26,7 +26,8 @@ Instead, it *returns* a new, connected component class, for you to use.
      - `andThen(value, meta): { prop: request, ... }` *(Function)*: returns an object of request mappings to fetch after fulfillment of this request but does not replace this request. Takes the `value` and `meta` of this request as arguments.
      - `andCatch(reason, meta): { prop: request, ... }` *(Function)*: returns an object of request mappings to fetch after rejection of this request but does not replace this request. Takes the `value` and `meta` of this request as arguments.
      - `value` *(Any)*: Data to passthrough directly to `PromiseState` as an alternative to providing a URL. This is an advanced option used for static data and data transformations. 
-
+     - `meta` *(Any)*: Metadata to passthrough directly to `PromiseState`. This attribute is only recognized if `value` is also provided.
+     
 Requests specified as functions are not fetched immediately when props are received, but rather bound to the props and injected into the component to be called at a later time in response to user actions. Functions should be pure and return the same format as `mapPropsToRequestsToProps` itself. If a function maps a request to the same name as an existing prop, the prop will be overwritten. This is commonly used for taking some action that updates an existing `PromiseState`. Consider setting `refreshing: true` in such it situation. 
 
 * [`options`] *(Object)* If specified, further customizes the behavior of the connector.

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -179,7 +179,7 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
         const onRejection = this.createPromiseStateOnRejection(prop, mapping, startedAt)
 
         if (mapping.value) {
-          const meta = {}
+          const meta = mapping.meta || {}
           this.setAtomicState(prop, startedAt, mapping, initPS(meta))
           return Promise.resolve(mapping.value).then(onFulfillment(meta), onRejection(meta))
         } else {

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -181,7 +181,7 @@ describe('React', () => {
     })
 
     it('should passthrough value of identity requests', (done) => {
-      @connect(() => ({ testFetch: { value: 'foo' } }))
+      @connect(() => ({ testFetch: { value: 'foo', meta: 'voodoo' } }))
       class Container extends Component {
         render() {
           return <Passthrough {...this.props} />
@@ -197,7 +197,7 @@ describe('React', () => {
 
       const stub = TestUtils.findRenderedComponentWithType(container, Passthrough)
       expect(stub.props.testFetch).toIncludeKeyValues({
-        fulfilled: false, pending: true, refreshing: false, reason: null, rejected: false, settled: false, value: null
+        fulfilled: false, pending: true, refreshing: false, reason: null, rejected: false, settled: false, value: null, meta: 'voodoo'
       })
 
       setImmediate(() => {
@@ -206,7 +206,7 @@ describe('React', () => {
 
         const stub = TestUtils.findRenderedComponentWithType(container, Passthrough)
         expect(stub.props.testFetch).toIncludeKeyValues({
-          fulfilled: true, pending: false, refreshing: false, reason: null, rejected: false, settled: true, value: 'foo'
+          fulfilled: true, pending: false, refreshing: false, reason: null, rejected: false, settled: true, value: 'foo', meta: 'voodoo'
         })
         done()
       })


### PR DESCRIPTION
Identity requests (i.e. requests with `value`) should also support `meta` to pass along to along in transformations; otherwise, this metadata gets lost and is not accessible by the component.