### PR TITLE
Allow to set the request mode in options

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -71,6 +71,7 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
       {
         method: 'GET',
         credentials: 'same-origin',
+        mode: 'cors',
         redirect: 'follow'
       },
       mapping,
@@ -91,6 +92,7 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
       method: mapping.method,
       headers: mapping.headers,
       credentials: mapping.credentials,
+      mode: mapping.mode,
       redirect: mapping.redirect,
       body: mapping.body
     })

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -171,10 +171,11 @@ describe('React', () => {
       )
 
       const decorated = TestUtils.findRenderedComponentWithType(container, Container)
-      expect(Object.keys(decorated.state.mappings.testFetch).length).toEqual(6)
+      expect(Object.keys(decorated.state.mappings.testFetch).length).toEqual(7)
       expect(decorated.state.mappings.testFetch.method).toEqual('POST')
       expect(decorated.state.mappings.testFetch.headers).toEqual({ Accept: 'application/json', 'Content-Type': 'overwrite-default', 'X-Foo': 'custom-foo' })
       expect(decorated.state.mappings.testFetch.credentials).toEqual('same-origin')
+      expect(decorated.state.mappings.testFetch.mode).toEqual('cors')
       expect(decorated.state.mappings.testFetch.redirect).toEqual('follow')
       expect(decorated.state.mappings.testFetch.url).toEqual('/example')
       expect(decorated.state.mappings.testFetch.equals).toBeA('function')


### PR DESCRIPTION
Allow to configure request mode in case you want to make a request to a site that doesn’t support CORS.
