### PR TITLE
Passthrough meta

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -25,8 +25,8 @@ Instead, it *returns* a new, connected component class, for you to use.
      - `catch(reason, meta): request` *(Function)*: returns a request to fetch after rejection of this request and replaces this request. Takes the `value` and `meta` of this request as arguments.
      - `andThen(value, meta): { prop: request, ... }` *(Function)*: returns an object of request mappings to fetch after fulfillment of this request but does not replace this request. Takes the `value` and `meta` of this request as arguments.
      - `andCatch(reason, meta): { prop: request, ... }` *(Function)*: returns an object of request mappings to fetch after rejection of this request but does not replace this request. Takes the `value` and `meta` of this request as arguments.
-     - `value` *(Any)*: Data to passthrough directly to `PromiseState` as an alternative to providing a URL. This is an advanced option used for static data and data transformations. 
-     - `meta` *(Any)*: Metadata to passthrough directly to `PromiseState`. This attribute is only recognized if `value` is also provided.
+     - `value` *(Any)*: Data to passthrough directly to `PromiseState` as an alternative to providing a URL. This is an advanced option used for static data and data transformations. Also consider setting `meta`. 
+     - `meta` *(Object)*: Metadata to passthrough directly to `PromiseState`. Keys `request`, `response`, and future keys may be overwritten.
      
 Requests specified as functions are not fetched immediately when props are received, but rather bound to the props and injected into the component to be called at a later time in response to user actions. Functions should be pure and return the same format as `mapPropsToRequestsToProps` itself. If a function maps a request to the same name as an existing prop, the prop will be overwritten. This is commonly used for taking some action that updates an existing `PromiseState`. Consider setting `refreshing: true` in such it situation. 
 

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -53,6 +53,8 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
 
     mapping = assignDefaults(mapping)
 
+    invariant(isPlainObject(mapping.meta), 'meta for `%s` must be a plain object. Instead received %s', prop, mapping.meta)
+
     mapping.equals = function (that) {
       if (this.comparison !== undefined) {
         return this.comparison === that.comparison
@@ -71,7 +73,8 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
       {
         method: 'GET',
         credentials: 'same-origin',
-        redirect: 'follow'
+        redirect: 'follow',
+        meta: {}
       },
       mapping,
       {
@@ -174,17 +177,17 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
       }
 
       createPromise(prop, mapping, startedAt) {
+        const meta = mapping.meta
         const initPS = this.createInitialPromiseState(prop, mapping)
         const onFulfillment = this.createPromiseStateOnFulfillment(prop, mapping, startedAt)
         const onRejection = this.createPromiseStateOnRejection(prop, mapping, startedAt)
 
         if (mapping.value) {
-          const meta = mapping.meta || {}
           this.setAtomicState(prop, startedAt, mapping, initPS(meta))
           return Promise.resolve(mapping.value).then(onFulfillment(meta), onRejection(meta))
         } else {
           const request = buildRequest(mapping)
-          const meta = { request: request }
+          meta.request = request
           this.setAtomicState(prop, startedAt, mapping, initPS(meta))
 
           const fetched = window.fetch(request)

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -33,7 +33,12 @@ describe('React', () => {
       })
 
       @connect(({ foo, baz }) => ({
-        testFetch: `/${foo}/${baz}`,
+        testFetch: {
+          url: `/${foo}/${baz}`,
+          meta: {
+            test: 'voodoo'
+          }
+        },
         errorFetch: `/error`,
         testFunc: (arg1, arg2) => ({
           deferredFetch: `/${foo}/${baz}/deferred/${arg1}/${arg2}`
@@ -53,7 +58,7 @@ describe('React', () => {
       expect(stubPending.props.foo).toEqual('bar')
       expect(stubPending.props.baz).toEqual(42)
       expect(stubPending.props.testFetch).toIncludeKeyValues({
-        fulfilled: false, pending: true, refreshing: false, reason: null, rejected: false, settled: false, value: null, meta: {}
+        fulfilled: false, pending: true, refreshing: false, reason: null, rejected: false, settled: false, value: null, meta: { test: 'voodoo' }
       })
       expect(stubPending.props.testFetch.constructor).toEqual(PromiseState)
 
@@ -78,6 +83,8 @@ describe('React', () => {
         expect(stubFulfilled.props.testFetch).toIncludeKeyValues({
           fulfilled: true, pending: false, refreshing: false, reason: null, rejected: false, settled: true, value: { T: 't' }
         })
+        expect(stubFulfilled.props.testFetch.meta.test).toEqual('voodoo')
+        expect(stubFulfilled.props.testFetch.meta.request.headers.get('Accept')).toEqual('application/json')
         expect(stubFulfilled.props.testFetch.meta.request.headers.get('Accept')).toEqual('application/json')
         expect(stubFulfilled.props.testFetch.meta.response.headers.get('A')).toEqual('a')
         expect(stubFulfilled.props.testFetch.meta.response.status).toEqual(200)
@@ -171,7 +178,7 @@ describe('React', () => {
       )
 
       const decorated = TestUtils.findRenderedComponentWithType(container, Container)
-      expect(Object.keys(decorated.state.mappings.testFetch).length).toEqual(6)
+      expect(Object.keys(decorated.state.mappings.testFetch).length).toEqual(7)
       expect(decorated.state.mappings.testFetch.method).toEqual('POST')
       expect(decorated.state.mappings.testFetch.headers).toEqual({ Accept: 'application/json', 'Content-Type': 'overwrite-default', 'X-Foo': 'custom-foo' })
       expect(decorated.state.mappings.testFetch.credentials).toEqual('same-origin')
@@ -181,7 +188,7 @@ describe('React', () => {
     })
 
     it('should passthrough value of identity requests', (done) => {
-      @connect(() => ({ testFetch: { value: 'foo', meta: 'voodoo' } }))
+      @connect(() => ({ testFetch: { value: 'foo', meta: { test: 'voodoo' } } }))
       class Container extends Component {
         render() {
           return <Passthrough {...this.props} />
@@ -197,7 +204,7 @@ describe('React', () => {
 
       const stub = TestUtils.findRenderedComponentWithType(container, Passthrough)
       expect(stub.props.testFetch).toIncludeKeyValues({
-        fulfilled: false, pending: true, refreshing: false, reason: null, rejected: false, settled: false, value: null, meta: 'voodoo'
+        fulfilled: false, pending: true, refreshing: false, reason: null, rejected: false, settled: false, value: null, meta: { test: 'voodoo' }
       })
 
       setImmediate(() => {
@@ -206,7 +213,7 @@ describe('React', () => {
 
         const stub = TestUtils.findRenderedComponentWithType(container, Passthrough)
         expect(stub.props.testFetch).toIncludeKeyValues({
-          fulfilled: true, pending: false, refreshing: false, reason: null, rejected: false, settled: true, value: 'foo', meta: 'voodoo'
+          fulfilled: true, pending: false, refreshing: false, reason: null, rejected: false, settled: true, value: 'foo', meta: { test: 'voodoo' }
         })
         done()
       })


### PR DESCRIPTION
Allow clients to set the initial `meta` value on the request. This is primarily for transformations with identity requests, but this generalizes the pattern for all requests.

Delivers #42 

cc: @jsullivan 