### PR TITLE
Update whatwg-fetch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "invariant": "^2.0.0"
   },
   "peerDependencies": {
-    "whatwg-fetch": "^0.10.1",
+    "whatwg-fetch": "*",
     "react": "^0.14.0"
   }
 }


### PR DESCRIPTION
Allow whatwg-fetch to accept any version. Allows it to be used with the latest version 0.11.0.