### PR TITLE
Immediately resolve PromiseState for identity requests

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -183,8 +183,7 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
         const onRejection = this.createPromiseStateOnRejection(prop, mapping, startedAt)
 
         if (mapping.value) {
-          this.setAtomicState(prop, startedAt, mapping, initPS(meta))
-          return Promise.resolve(mapping.value).then(onFulfillment(meta), onRejection(meta))
+          return onFulfillment(meta)(mapping.value)
         } else {
           const request = buildRequest(mapping)
           meta.request = request

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -187,7 +187,7 @@ describe('React', () => {
       expect(decorated.state.mappings.testFetch.equals).toBeA('function')
     })
 
-    it('should passthrough value of identity requests', (done) => {
+    it('should passthrough value of identity requests', () => {
       @connect(() => ({ testFetch: { value: 'foo', meta: { test: 'voodoo' } } }))
       class Container extends Component {
         render() {
@@ -204,18 +204,7 @@ describe('React', () => {
 
       const stub = TestUtils.findRenderedComponentWithType(container, Passthrough)
       expect(stub.props.testFetch).toIncludeKeyValues({
-        fulfilled: false, pending: true, refreshing: false, reason: null, rejected: false, settled: false, value: null, meta: { test: 'voodoo' }
-      })
-
-      setImmediate(() => {
-        const decorated = TestUtils.findRenderedComponentWithType(container, Container)
-        expect(decorated.state.mappings.testFetch.value).toEqual('foo')
-
-        const stub = TestUtils.findRenderedComponentWithType(container, Passthrough)
-        expect(stub.props.testFetch).toIncludeKeyValues({
-          fulfilled: true, pending: false, refreshing: false, reason: null, rejected: false, settled: true, value: 'foo', meta: { test: 'voodoo' }
-        })
-        done()
+        fulfilled: true, pending: false, refreshing: false, reason: null, rejected: false, settled: true, value: 'foo', meta: { test: 'voodoo' }
       })
     })
 


### PR DESCRIPTION
Not 100% (about 95%) sure we want to do this, but this fixes #63. It skips the `pending` state and resolves the `PromiseState` immediately for identity requests. See the [issue](https://github.com/heroku/react-refetch/issues/63) for some questions to consider. 

cc: @neezer @jsullivan 