### PR TITLE
Skip Response Body Parsing If Empty

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -103,7 +103,12 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
   }
 
   function handleResponse(response) {
+    if (response.headers.get('content-length') === '0' || response.status === 204) {
+      return
+    }
+
     const json = response.json() // TODO: support other response types
+
     if (response.status >= 200 && response.status < 300) { // TODO: support custom acceptable statuses
       return json
     } else {

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -949,6 +949,70 @@ describe('React', () => {
       expect(decorated.refs.wrappedInstance.someInstanceMethod()).toBe(someData)
     })
 
+    it('should not parse the body if response is a 204', (done) => {
+      window.fetch = () => {
+        return new Promise((resolve) => {
+          resolve(new window.Response('', { status: 204 }))
+        })
+      }
+
+      @connect(() => ({ testFetch: `/empty` }))
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      const container = TestUtils.renderIntoDocument(
+        <Container />
+      )
+
+      const init = TestUtils.findRenderedComponentWithType(container, Container)
+      expect(init.state.data.testFetch).toIncludeKeyValues(
+        { fulfilled: false, pending: true, reason: null, refreshing: false, rejected: false, settled: false, value: null }
+      )
+
+      setImmediate(() => {
+        const fulfilled = TestUtils.findRenderedComponentWithType(container, Container)
+        expect(fulfilled.state.data.testFetch).toIncludeKeyValues(
+          { fulfilled: true, pending: false, reason: null, refreshing: false, rejected: false, settled: true, value: null }
+        )
+        done()
+      })
+    })
+
+    it('should not parse the body if response has Content-Length: 0', (done) => {
+      window.fetch = () => {
+        return new Promise((resolve) => {
+          resolve(new window.Response('', { status: 200, headers: { 'Content-Length': 0 } }))
+        })
+      }
+
+      @connect(() => ({ testFetch: `/empty` }))
+      class Container extends Component {
+        render() {
+          return <Passthrough {...this.props} />
+        }
+      }
+
+      const container = TestUtils.renderIntoDocument(
+        <Container />
+      )
+
+      const init = TestUtils.findRenderedComponentWithType(container, Container)
+      expect(init.state.data.testFetch).toIncludeKeyValues(
+        { fulfilled: false, pending: true, reason: null, refreshing: false, rejected: false, settled: false, value: null }
+      )
+
+      setImmediate(() => {
+        const fulfilled = TestUtils.findRenderedComponentWithType(container, Container)
+        expect(fulfilled.state.data.testFetch).toIncludeKeyValues(
+          { fulfilled: true, pending: false, reason: null, refreshing: false, rejected: false, settled: true, value: null }
+        )
+        done()
+      })
+    })
+
     // TODO
     //it('should not render the wrapped component when mapState does not produce change', () => {
     //  const store = createStore(stringBuilder)


### PR DESCRIPTION
Checks that the response 

- is not a `204: No Content`
- does not have a `Content-Length` header equal to `0`

If either of these are true, `handleResponse` skips parsing the response body.

Fixes #67

cc: @ryanbrainard 