### PR TITLE
mapPropsToRequestsToProps is called with context as 2nd argument (closes #69)

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -9,7 +9,7 @@ Instead, it *returns* a new, connected component class, for you to use.
 
 #### Arguments
 
-* [`mapPropsToRequestsToProps(props): { prop: request, ... }`] *(Function)*: A pure function of props that specifies the requests to fetch data and the props to which to assign the results. This function is called every time props change, and if the requests materially change, the data will be refetched. Requests can be specified as plain URL strings, request objects, or functions. Plain URL strings are the most common and preferred format, but only support GET URLs with default options. For more advanced options, specify the request as an object with the following keys:
+* [`mapPropsToRequestsToProps(props, context): { prop: request, ... }`] *(Function)*: A pure function of props (and context, if the wrapped component defines contextTypes) that specifies the requests to fetch data and the props to which to assign the results. This function is called every time props or context change, and if the requests materially change, the data will be refetched. Requests can be specified as plain URL strings, request objects, or functions. Plain URL strings are the most common and preferred format, but only support GET URLs with default options. For more advanced options, specify the request as an object with the following keys:
 
      - `url` *(String)*: Required. HTTP URL from which to fetch the data.
      - `method` *(String)*: HTTP method. Defaults to `GET`.

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -128,8 +128,8 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
         this.refetchDataFromProps()
       }
 
-      componentWillReceiveProps(nextProps) {
-        this.refetchDataFromProps(nextProps)
+      componentWillReceiveProps(nextProps, nextContext) {
+        this.refetchDataFromProps(nextProps, nextContext)
       }
 
       componentWillUnmount() {
@@ -152,8 +152,8 @@ export default function connect(mapPropsToRequestsToProps, options = {}) {
         return this.refs.wrappedInstance
       }
 
-      refetchDataFromProps(props = this.props) {
-        this.refetchDataFromMappings(finalMapPropsToRequestsToProps(props) || {})
+      refetchDataFromProps(props = this.props, context = this.context) {
+        this.refetchDataFromMappings(finalMapPropsToRequestsToProps(props, context) || {})
       }
 
       refetchDataFromMappings(mappings) {

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -587,6 +587,65 @@ describe('React', () => {
       })
     })
 
+    it('should invoke mapPropsToRequestsToProps with context', () => {
+      let contextPassedIn = []
+
+      @connect((props, context) => {
+        contextPassedIn.push(context)
+        return {}
+      })
+      class InnerComponent extends Component {
+        render() {
+          return <div />
+        }
+      }
+      InnerComponent.contextTypes = {
+        foo: React.PropTypes.string
+      }
+
+      class OuterComponent extends Component {
+        constructor(props) {
+          super(props)
+          this.state = {
+            foo: 'bar'
+          }
+        }
+
+        getChildContext() {
+          return {
+            foo: this.state.foo
+          }
+        }
+
+        setFoo(foo) {
+          this.setState({ foo })
+        }
+
+        render() {
+          return <InnerComponent />
+        }
+      }
+      OuterComponent.childContextTypes = {
+        foo: React.PropTypes.string
+      }
+
+      let outerComponent
+      TestUtils.renderIntoDocument(
+        <OuterComponent ref={c => outerComponent = c} />
+      )
+
+      outerComponent.setFoo('baz')
+
+      expect(contextPassedIn).toEqual([
+        {
+          foo: 'bar'
+        },
+        {
+          foo: 'baz'
+        }
+      ])
+    })
+
     it('should shallowly compare the requests to prevent unnecessary fetches', (done) => {
       const fetchSpy = expect.createSpy(() => ({}))
       fetchSpies.push(fetchSpy)


### PR DESCRIPTION
@ryanbrainard any other test you can think is appropriate?
I'm testing
- context is indeed provided as the 2nd argument
- when context changes mapPropsToRequestsToProps is called with the new context