### PR TITLE
added context example to README

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,6 +7,7 @@
   },
   "rules": {
     "valid-jsdoc": 2,
+    "curly": 2,
     "react/jsx-uses-react": 1,
     "react/jsx-no-undef": 2,
     "react/wrap-multilines": 2

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ You can also use `context` (in addition to props) to help define the requests yo
 It's available as the second argument to the function you pass to `connect`.
 Don't forget to define `contextTypes` on the component you're wrapping for context to be available.
 
-Some use case examples are, eg. setting a urlPrefix in a root component that all others use:
+Some use case examples are, eg. setting a URL prefix in a root component that all others use:
 ```js
 connect((props, context) => {
   return {
@@ -368,7 +368,7 @@ connect((props, context) => {
 })(Profile)
 ```
 
-This is a complete example of everything you need to use context with react-refetch:
+This is a complete example of everything you need to use context with React Refetch:
 ```jsx
 import React, { Component, PropTypes } from 'react'
 import { connect, PromiseState } from 'react-refetch'

--- a/README.md
+++ b/README.md
@@ -341,6 +341,83 @@ userFetch.meta.response.headers.get('FOO')
 
 Do not attempt to read bodies directly from `meta.request` or `meta.response`. They are provided for metadata purposes only.
 
+## Using context to define requests
+
+You can also use `context` (in addition to props) to help define the requests your components need.
+It's available as the second argument to the function you pass to `connect`.
+Don't forget to define `contextTypes` on the component you're wrapping for context to be available.
+
+Some use case examples are, eg. setting a urlPrefix in a root component that all others use:
+```js
+connect((props, context) => {
+  return {
+    userFetch: `${context.apiPrefix}/user/${props.params.userId}`
+  }
+})(Profile)
+```
+or also, setting a common refresh interval used by all components that need it:
+```js
+connect((props, context) => {
+  return {
+    userFetch: `/user/${props.params.userId}`,
+    likesFetch: {
+      url: `/users/${props.userId}/likes`,
+      refreshInterval: context.refreshInterval,
+    }
+  }
+})(Profile)
+```
+
+This is a complete example of everything you need to use context with react-refetch:
+```jsx
+import React, { Component, PropTypes } from 'react'
+import { connect, PromiseState } from 'react-refetch'
+
+class App extends React.Component {
+  static childContextTypes = {
+    apiPrefix: PropTypes.string.isRequired,
+  }
+
+  getChildContext() {
+    return {
+      apiPrefix: '/api/v1'
+    }
+  }
+
+  render() {
+    return <Profile params={this.props.params} />
+  }
+}
+
+class Profile extends React.Component {
+  static propTypes = {
+    userFetch: PropTypes.instanceOf(PromiseState).isRequired,
+  }
+
+  static contextTypes = {
+    apiPrefix: PropTypes.string.isRequired,
+  }
+
+  render() {
+    const { userFetch } = this.props
+
+    if (userFetch.pending) {
+      return <LoadingAnimation/>
+    } else if (userFetch.rejected) {
+      return <Error error={userFetch.reason}/>
+    } else if (userFetch.fulfilled) {
+      return <User data={userFetch.value}/>
+    }
+  }
+}
+
+export default connect((props, context) => {
+  return {
+    userFetch: `${context.apiPrefix}/user/${props.params.userId}`
+  }
+})(Profile)
+```
+
 ## Complete Example
 
 This is a complex example demonstrating various feature at once:

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "prepublish": "npm run clean && npm run lint && npm run build",
     "test": "mocha --compilers js:babel-core/register --recursive --require ./test/setup.js",
     "test:watch": "npm test -- --watch",
-    "test:cov": "babel-node ./node_modules/isparta/bin/isparta cover ./node_modules/mocha/bin/_mocha -- --recursive"
+    "test:cov": "babel-node ./node_modules/isparta/bin/isparta cover ./node_modules/mocha/bin/_mocha -- --recursive --require ./test/setup.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
@ryanbrainard I finally got around to writing an example for context, what do you think, is this what you had in mind?

(related to https://github.com/heroku/react-refetch/pull/86)

I've also made two other changes in this PR (I wans't sure if I should open separate PRs for such small things):
- added the `curly` eslint rule as we discussed in a previous PR
- fixed `npm run test:cov` which wasn't working