### PR TITLE
type check mappings, allow all defaults at the mapping level, general housekeeping

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -136,22 +136,16 @@ function connect(mapPropsToRequestsToProps, defaults) {
   }
 
   defaults = Object.assign({
-    andCatch: undefined,
-    andThen: undefined,
     buildRequest,
-    catch: undefined,
-    comparison: undefined,
     credentials: 'same-origin',
     fetch: topFetch,
     force: false,
     handleResponse,
-    headers: {},
     method: 'GET',
     redirect: 'follow',
     refreshing: false,
     refreshInterval: 0,
     Request: topRequest,
-    then: undefined,
     withRef: false
   }, defaults)
 
@@ -219,30 +213,18 @@ function connect(mapPropsToRequestsToProps, defaults) {
     }
 
     return Object.assign(
-      { comparison: defaults.comparison },
-      parent ? {
-        comparison: parent.comparison
-      } : {},
       {
-        andCatch: defaults.andCatch,
-        andThen: defaults.andThen,
-        catch: defaults.catch,
-        credentials: defaults.credentials,
-        force: defaults.force,
-        meta: {},
-        method: defaults.method,
-        redirect: defaults.redirect,
-        refreshing: defaults.refreshing,
-        refreshInterval: defaults.refreshInterval,
-        then: defaults.then
+        meta: {}
       },
+      defaults,
+      parent ? { comparison: parent.comparison } : {},
       mapping,
       { headers }
     )
   }
 
   function buildRequest(mapping) {
-    return new defaults.Request(mapping.url, {
+    return new mapping.Request(mapping.url, {
       method: mapping.method,
       headers: mapping.headers,
       credentials: mapping.credentials,
@@ -343,14 +325,15 @@ function connect(mapPropsToRequestsToProps, defaults) {
         if (mapping.hasOwnProperty('value')) {
           return onFulfillment(meta)(mapping.value)
         } else {
-          const request = defaults.buildRequest(mapping)
+          const request = mapping.buildRequest(mapping)
           meta.request = request
           this.setAtomicState(prop, startedAt, mapping, initPS(meta))
 
-          const fetched = defaults.fetch(request)
+          const fetched = mapping.fetch(request)
           return fetched.then(response => {
             meta.response = response
-            return fetched.then(defaults.handleResponse).then(onFulfillment(meta), onRejection(meta))
+            return fetched.then(mapping.handleResponse)
+              .then(onFulfillment(meta), onRejection(meta))
           })
         }
       }

--- a/src/utils/buildRequest.js
+++ b/src/utils/buildRequest.js
@@ -1,0 +1,9 @@
+export default function buildRequest(mapping) {
+  return new mapping.Request(mapping.url, {
+    method: mapping.method,
+    headers: mapping.headers,
+    credentials: mapping.credentials,
+    redirect: mapping.redirect,
+    body: mapping.body
+  })
+}

--- a/src/utils/checkTypes.js
+++ b/src/utils/checkTypes.js
@@ -1,0 +1,88 @@
+import invariant from 'invariant'
+import isPlainObject from './isPlainObject'
+
+function typecheck(type, name, obj) {
+  invariant(
+    typeof obj === type,
+    `${name} must be a ${type}. Instead received a %s.`,
+    typeof obj
+  )
+}
+
+const checks = {
+  buildRequest(fn) {
+    typecheck('function', 'buildRequest', fn)
+  },
+
+  credentials(str) {
+    const allowed = [ 'omit', 'same-origin', 'include' ]
+    invariant(
+      allowed.indexOf(str) !== -1,
+      `credentials must be one of ${allowed.join(', ')}. Instead got %s.`,
+      str ? str.toString() : str
+    )
+  },
+
+  fetch(fn) {
+    typecheck('function', 'fetch', fn)
+  },
+
+  handleResponse(fn) {
+    typecheck('function', 'handleResponse', fn)
+  },
+
+  headers(obj) {
+    invariant(
+      isPlainObject(obj),
+      'headers must be a plain object with string values. Instead received a %s.',
+      typeof obj
+    )
+  },
+
+  method(str) {
+    typecheck('string', 'method', str)
+  },
+
+  redirect(str) {
+    const allowed = [ 'follow', 'error', 'manual' ]
+    invariant(
+      allowed.indexOf(str) !== -1,
+      `redirect must be one of ${allowed.join(', ')}. Instead got %s.`,
+      str ? str.toString() : str
+    )
+  },
+
+  refreshInterval(num) {
+    typecheck('number', 'refreshInterval', num)
+    invariant(num >= 0, 'refreshInterval must be positive or 0.')
+    invariant(num !== Infinity, 'refreshInterval must not be Infinity.')
+  },
+
+  Request(fn) {
+    typecheck('function', 'Request', fn)
+  },
+
+  then(fn) {
+    typecheck('function', 'then', fn)
+  },
+
+  andThen(fn) {
+    typecheck('function', 'andThen', fn)
+  },
+
+  catch(fn) {
+    typecheck('function', 'catch', fn)
+  },
+
+  andCatch(fn) {
+    typecheck('function', 'andCatch', fn)
+  }
+}
+
+export default function checkTypes(mapping) {
+  Object.keys(mapping).forEach(key => {
+    if (checks[key]) {
+      checks[key](mapping[key])
+    }
+  })
+}

--- a/src/utils/handleResponse.js
+++ b/src/utils/handleResponse.js
@@ -1,0 +1,15 @@
+import newError from './errors'
+
+export default function handleResponse(response) {
+  if (response.headers.get('content-length') === '0' || response.status === 204) {
+    return
+  }
+
+  const json = response.json() // TODO: support other response types
+
+  if (response.status >= 200 && response.status < 300) { // TODO: support custom acceptable statuses
+    return json
+  } else {
+    return json.then(cause => Promise.reject(newError(cause)))
+  }
+}


### PR DESCRIPTION
## todo

- [x] handleResponse moved to separate file in utils
- [x] buildRequest moved to separate file in utils
- [x] type checks moved to separate file in utils
- [x] tests that had copy-pasted handleResponse/buildRequest now import them
- [x] simplified defaults assignment
  - [x] fetch, handleResponse, buildRequest and Request can now be set at the mapping level
  - [x] every option can now be set at the individual mapping or defaults level
- [x] deprecated options argument to connect only sets withRef
- [x] added type checking for then, catch, andThen, andCatch
- [x] added tests checking type checking for then, catch, andThen, andCatch
- [x] added test checking that options at the mapping level take precedence over defaults
  - [x] tests that mapping level fetch, handleResponse, buildRequest, Request are used 