### PR TITLE
Fix test '...shallowly compare the requests...' since componentWillReceiveProps optimisation

### DIFF
--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -1022,7 +1022,7 @@ describe('React', () => {
         return <Passthrough/>
       }
 
-      @connect(({ foo }) => ({ testFetch: `/resource/${foo}` }))
+      @connect(({ foo }) => ({ testFetch: `/resource/${foo.FOO}` }))
       class WithProps extends Component {
         render() {
           return render(this.props)
@@ -1032,11 +1032,15 @@ describe('React', () => {
       class OuterComponent extends Component {
         constructor() {
           super()
-          this.state = { foo: 'FOO' }
+          this.state = {
+            foo: {
+              FOO: 'FOO'
+            }
+          }
         }
 
-        setFoo(foo) {
-          this.setState({ foo })
+        setFoo(FOO) {
+          this.setState({ foo: { FOO } })
         }
 
         render() {


### PR DESCRIPTION
When the componentWillReceiveProps optimisation was added I accidentally changed this test such that it no longer tested what it was meant to test:
  - seeing as the componentWillReceiveProps optimisation prevents calling mapPropsToRequestsToProps from being called if the props are shallowly equal, this test's `this.setState({ foo })` didn't make it past componentWillReceiveProps so request comparison wasn't being tested
	- this commit changes that to `this.setState({ foo: { FOO } })` so that the props are not shallowly equal (but deeply equal) and request comparison is actually tested