### PR TITLE
Add PromiseState.cast and follow in PromiseState.resolve

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -109,6 +109,8 @@ Properties should be treated as read-only and immutable. If the `Promise` enters
 
 ##### `refresh(previous: PromiseState, meta): PromiseState`
 
+##### `cast(value, meta): PromiseState`
+
 ##### `resolve(value, meta): PromiseState`
 
 ##### `reject(value, meta): PromiseState`

--- a/test/PromiseState.spec.js
+++ b/test/PromiseState.spec.js
@@ -9,6 +9,49 @@ describe('PromiseState', () => {
   const onFulFilledToPromiseState = (v) => PromiseState.resolve(`F[${v}]`)
   const onRejectedToPromiseState  = (r) => PromiseState.resolve(`R[${r}]`)
 
+  describe('resolve', () => {
+    it('resolves raw value', () => {
+      const ps = PromiseState.resolve('x')
+      expect(ps.fulfilled).toBe(true)
+      expect(ps.value).toBe('x')
+    })
+
+    it('returns provided fulfilled PromiseState value', () => {
+      const ps = PromiseState.resolve(PromiseState.resolve('x'))
+      expect(ps.fulfilled).toBe(true)
+      expect(ps.value).toBe('x')
+    })
+
+    it('returns provided non-fulfilled PromiseState value', () => {
+      expect(() => {
+        PromiseState.resolve(PromiseState.reject('x'))
+      }).toThrow('PromiseState must be fulfilled')
+    })
+  })
+
+  describe('cast', () => {
+    it('returns PromiseStresolves other values', () => {
+      const ps = PromiseState.cast(PromiseState.resolve('x', 'm'), 'M')
+      expect(ps.fulfilled).toBe(true)
+      expect(ps.value).toBe('x')
+      expect(ps.meta).toBe('m')
+    })
+
+    it('rejects Error', () => {
+      const ps = PromiseState.cast(new Error('x'), 'm')
+      expect(ps.rejected).toBe(true)
+      expect(ps.reason.message).toBe('x')
+      expect(ps.meta).toBe('m')
+    })
+
+    it('resolves other values', () => {
+      const ps = PromiseState.cast('x', 'm')
+      expect(ps.fulfilled).toBe(true)
+      expect(ps.value).toBe('x')
+      expect(ps.meta).toBe('m')
+    })
+  })
+
   describe('then', () => {
     it('pending', () => {
       const ps = PromiseState.create().then(onFulFilled, onRejected)


### PR DESCRIPTION
Fixes #97 

This adds `PromiseState.cast` to create a `PromiseState` from a value that may be already a `PromiseState`. If it is, it just returns it. If not, it creates a `PromiseState` and resolves or rejects depending on it being an `Error`.

This also adds similar treatment to `PromiseState.resolve`, but only if it is fulfilled. This has limited utility, but is mostly for parity with `Promise.resolve`.

cc: @nfcampos 