### PR TITLE
Return existing PromiseState from PromiseState.resolve

### DIFF
--- a/src/PromiseState.js
+++ b/src/PromiseState.js
@@ -16,8 +16,14 @@ export default class PromiseState {
     return ps
   }
 
-  // creates a PromiseState that is resolved with the given value
+  // creates a PromiseState that is resolved with the given value.
+  // if the given value is already a PromiseState,
+  // it will be returned as is and ignore the provided meta.
   static resolve(value, meta) {
+    if (value instanceof PromiseState) {
+      return value
+    }
+
     return new PromiseState({
       fulfilled: true,
       value: value,

--- a/test/PromiseState.spec.js
+++ b/test/PromiseState.spec.js
@@ -9,6 +9,26 @@ describe('PromiseState', () => {
   const onFulFilledToPromiseState = (v) => PromiseState.resolve(`F[${v}]`)
   const onRejectedToPromiseState  = (r) => PromiseState.resolve(`R[${r}]`)
 
+  describe('resolve', () => {
+    it('resolves raw value', () => {
+      const ps = PromiseState.resolve('x')
+      expect(ps.fulfilled).toBe(true)
+      expect(ps.value).toBe('x')
+    })
+
+    it('returns provided fulfilled PromiseState value', () => {
+      const ps = PromiseState.resolve(PromiseState.resolve('x'))
+      expect(ps.fulfilled).toBe(true)
+      expect(ps.value).toBe('x')
+    })
+
+    it('returns provided non-fulfilled PromiseState value', () => {
+      const ps = PromiseState.resolve(PromiseState.reject('x'))
+      expect(ps.rejected).toBe(true)
+      expect(ps.reason).toBe('x')
+    })
+  })
+
   describe('then', () => {
     it('pending', () => {
       const ps = PromiseState.create().then(onFulFilled, onRejected)


### PR DESCRIPTION
Fixes #97 (and drops the now unneeded `#cast` from #105)

cc: @nfcampos 