### PR TITLE
fixes handling of rejected fetches

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -253,11 +253,13 @@ function connect(mapPropsToRequestsToProps, defaults, options) {
           this.setAtomicState(prop, startedAt, mapping, initPS(meta))
 
           const fetched = mapping.fetch(request)
-          return fetched.then(response => {
-            meta.response = response
-            return fetched.then(mapping.handleResponse)
-              .then(onFulfillment(meta), onRejection(meta))
-          })
+          return fetched
+            .then(response => {
+              meta.response = response
+              return response
+            })
+            .then(mapping.handleResponse)
+            .then(onFulfillment(meta), onRejection(meta))
         }
       }
 


### PR DESCRIPTION
- fetch rejects rarely, but it does happen (eg. when the request times out), see https://fetch.spec.whatwg.org/#fetch-method for details
- fixed promise chaining in RefetchConnect#createPromise
- added tests for this behaviour
  - added another branch to our testing fetch stub (which rejects the promise)
  - added rejected fetch case to the 'should should props and promise state to the given component' test
  - tested that catch and andCatch handlers of a rejected request are called