### PR TITLE
Delay json parsing

### DIFF
--- a/src/utils/handleResponse.js
+++ b/src/utils/handleResponse.js
@@ -8,6 +8,6 @@ export default function handleResponse(response) {
   if (response.status >= 200 && response.status < 300) { // TODO: support custom acceptable statuses
     return response.json() // TODO: support other response types
   } else {
-    return json.then(cause => Promise.reject(newError(cause)))
+    return Promise.reject(newError(response.statusText))
   }
 }

--- a/src/utils/handleResponse.js
+++ b/src/utils/handleResponse.js
@@ -5,10 +5,8 @@ export default function handleResponse(response) {
     return
   }
 
-  const json = response.json() // TODO: support other response types
-
   if (response.status >= 200 && response.status < 300) { // TODO: support custom acceptable statuses
-    return json
+    return response.json() // TODO: support other response types
   } else {
     return json.then(cause => Promise.reject(newError(cause)))
   }


### PR DESCRIPTION
Prevents SyntaxError being thrown, when trying to parse invalid json. Like the result of a 404 or 500 status.