### PR TITLE
fixed window.fetch mocks leaking from one test to another

### DIFF
--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -6,6 +6,8 @@ import { connect, PromiseState } from '../../src/index'
 import buildRequest from '../../src/utils/buildRequest'
 import handleResponse from '../../src/utils/handleResponse'
 
+process.on('unhandledRejection', e => { throw e })
+
 describe('React', () => {
   describe('connect', () => {
 


### PR DESCRIPTION
- test are failing now because this uncovered an issue with setting a default `then`, see #119 