### PR TITLE
Fix infinite then

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -164,7 +164,14 @@ function connect(mapPropsToRequestsToProps, defaults, options) {
         meta: {}
       },
       defaults,
-      parent ? { comparison: parent.comparison } : {},
+      parent ? {
+        fetch: parent.fetch,
+        buildRequest: parent.buildRequest,
+        handleResponse: parent.handleResponse,
+        comparison: parent.comparison,
+        then: undefined,
+        andThen: undefined
+      } : {},
       mapping,
       { headers }
     )

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -6,6 +6,8 @@ import { connect, PromiseState } from '../../src/index'
 import buildRequest from '../../src/utils/buildRequest'
 import handleResponse from '../../src/utils/handleResponse'
 
+process.on('unhandledRejection', e => { throw e })
+
 describe('React', () => {
   describe('connect', () => {
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -2679,7 +2679,7 @@ describe('React', () => {
       })
 
       it('should set the default andThen', () => {
-        const custom = connect.defaults({ andThen: (v) => `/second/${v['T']}` })
+        const custom = connect.defaults({ andThen: (v) => ({ secondFetch: `/second/${v['T']}` }) })
         @custom(({ foo }) => ({ firstFetch: `/first/${foo}` }))
         class Container extends Component {
           render() {
@@ -2707,7 +2707,7 @@ describe('React', () => {
       })
 
       it('should set the default andCatch', () => {
-        const custom = connect.defaults({ andCatch: (v) => `/second/${v['T']}` })
+        const custom = connect.defaults({ andCatch: (v) => ({ secondFetch: `/second/${v['T']}` }) })
         @custom(({ foo }) => ({ firstFetch: `/first/${foo}` }))
         class Container extends Component {
           render() {
@@ -2726,19 +2726,19 @@ describe('React', () => {
         const buildRequestDefault = expect.createSpy().andCall(buildRequest)
 
         const custom = connect.defaults({
-          then: (v) => `/second/${v['T']}`,
-          andThen: (v) => `/second/${v['T']}`,
-          catch: (v) => `/second/${v['T']}`,
-          andCatch: (v) => `/second/${v['T']}`,
+          then: (v) => `/second/default/then/${v['T']}`,
+          andThen: (v) => ({ secondFetch: `/second/default/andThen/${v['T']}` }),
+          catch: (v) => `/second/default/catch/${v['T']}`,
+          andCatch: (v) => ({ secondFetch: `/second/default/andCatch/${v['T']}` }),
           fetch: fetchDefault,
           handleResponse: handleResponseDefault,
           buildRequest: buildRequestDefault
         })
 
-        const then = (v) => `/second/${v['T']}`
-        const andThen = (v) => `/second/${v['T']}`
-        const ccatch = (v) => `/second/${v['T']}`
-        const andCatch = (v) => `/second/${v['T']}`
+        const then = (v) => `/second/inline/then/${v['T']}`
+        const andThen = (v) => ({ secondFetch: `/second/inline/andThen/${v['T']}` })
+        const ccatch = (v) => `/second/inline/catch/${v['T']}`
+        const andCatch = (v) => ({ secondFetch: `/second/inline/andCatch/${v['T']}` })
 
         const fetchSpy = expect.createSpy().andCall(window.fetch)
         const handleResponseSpy = expect.createSpy().andCall(handleResponse)
@@ -2773,9 +2773,9 @@ describe('React', () => {
           expect(fetchDefault.calls.length).toBe(0)
           expect(handleResponseDefault.calls.length).toBe(0)
           expect(buildRequestDefault.calls.length).toBe(0)
-          expect(fetchSpy.calls.length).toBe(1)
-          expect(handleResponseSpy.calls.length).toBe(1)
-          expect(buildRequestSpy.calls.length).toBe(1)
+          expect(fetchSpy.calls.length).toBe(2)
+          expect(handleResponseSpy.calls.length).toBe(2)
+          expect(buildRequestSpy.calls.length).toBe(2)
           done()
         })
       })


### PR DESCRIPTION
This builds on https://github.com/heroku/react-refetch/pull/120 and suggests a fix for https://github.com/heroku/react-refetch/issues/119. I'm not sure I love the special casing going on here, but this does at least seem like a reasonable default to not inherit `then` and `andThen` from the `parent`. I did not do the same for `catch` and `andCatch` because I'm assuming those would be default error handlers. Please let me know what you think.

In testing this, I realized that `fetch`, `buildRequest`, and `handleResponse` were not inherited. It seems like they should be. Thoughts? Any others we should consider?

cc: @jsullivan @nfcampos 