### PR TITLE
compare mapping against parent if it exists

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -144,7 +144,7 @@ function connect(mapPropsToRequestsToProps, defaults, options) {
       return [ 'value', 'url', 'method', 'headers', 'body' ].every((c) => {
         return shallowEqual(this[c], that[c])
       })
-    }.bind(mapping)
+    }.bind(parent || mapping)
 
     return mapping
   }

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -132,6 +132,10 @@ function connect(mapPropsToRequestsToProps, defaults, options) {
 
     checkTypes(mapping)
 
+    if (parent) {
+      mapping.parent = parent.parent || parent
+    }
+
     mapping = assignDefaults(mapping, parent)
 
     invariant(isPlainObject(mapping.meta), 'meta for `%s` must be a plain object. Instead received %s', prop, mapping.meta)
@@ -144,7 +148,7 @@ function connect(mapPropsToRequestsToProps, defaults, options) {
       return [ 'value', 'url', 'method', 'headers', 'body' ].every((c) => {
         return shallowEqual(this[c], that[c])
       })
-    }.bind(parent || mapping)
+    }.bind(mapping.parent || mapping)
 
     return mapping
   }


### PR DESCRIPTION
- basically just compares new mappings against the parent (if it exists). only goes one level deep so if you have 
```js
{
  foo: {
    url: '/foo',
    then: () => ({
      url: '/then',
      then: () => ({
        url: '/thenthen'
      })
    })
  }
}
```
it'll still be broken

- missing a test for this, don't merge yet

closes #102 

what do you think of this solution @ryanbrainard ?