### PR TITLE
added test for #125

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -141,6 +141,8 @@ function connect(mapPropsToRequestsToProps, defaults, options) {
     invariant(isPlainObject(mapping.meta), 'meta for `%s` must be a plain object. Instead received %s', prop, mapping.meta)
 
     mapping.equals = function (that) {
+      that = that.parent || that
+
       if (this.comparison !== undefined) {
         return this.comparison === that.comparison
       }
@@ -148,7 +150,7 @@ function connect(mapPropsToRequestsToProps, defaults, options) {
       return [ 'value', 'url', 'method', 'headers', 'body' ].every((c) => {
         return shallowEqual(this[c], that[c])
       })
-    }.bind(mapping.parent || mapping)
+    }.bind(mapping)
 
     return mapping
   }


### PR DESCRIPTION
turns out I had forgotten a test for #125 
and apparently it was needed, it is the `that` mapping in the `equals` function that needs to be always the parent (because the `that` mapping is the older one, `this` is the new mapping)