### PR TITLE
allow then, andThen, catch, andCatch to be undefined

### DIFF
--- a/src/utils/checkTypes.js
+++ b/src/utils/checkTypes.js
@@ -1,10 +1,12 @@
 import invariant from 'invariant'
 import isPlainObject from './isPlainObject'
 
-function typecheck(type, name, obj) {
+function typecheck(types, name, obj) {
   invariant(
-    typeof obj === type,
-    `${name} must be a ${type}. Instead received a %s.`,
+    Array.isArray(types)
+      ? types.some(t => typeof obj === t)
+      : typeof obj === types,
+    `${name} must be a ${types}. Instead received a %s.`,
     typeof obj
   )
 }
@@ -63,19 +65,19 @@ const checks = {
   },
 
   then(fn) {
-    typecheck('function', 'then', fn)
+    typecheck([ 'function', 'undefined' ], 'then', fn)
   },
 
   andThen(fn) {
-    typecheck('function', 'andThen', fn)
+    typecheck([ 'function', 'undefined' ], 'andThen', fn)
   },
 
   catch(fn) {
-    typecheck('function', 'catch', fn)
+    typecheck([ 'function', 'undefined' ], 'catch', fn)
   },
 
   andCatch(fn) {
-    typecheck('function', 'andCatch', fn)
+    typecheck([ 'function', 'undefined' ], 'andCatch', fn)
   }
 }
 

--- a/src/utils/checkTypes.js
+++ b/src/utils/checkTypes.js
@@ -6,7 +6,7 @@ function typecheck(types, name, obj) {
     Array.isArray(types)
       ? types.some(t => typeof obj === t)
       : typeof obj === types,
-    `${name} must be a ${types}. Instead received a %s.`,
+    `${name} must be ${Array.isArray(types) ? 'one of' : 'a'} ${types}. Instead received a %s.`,
     typeof obj
   )
 }

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -2268,7 +2268,7 @@ describe('React', () => {
         expectedTypes = Array.isArray(expectedTypes) ? expectedTypes : [ expectedTypes ]
         typeException = typeException || function (type) {
           return regexpify(
-            `${name} must be a ${expectedTypes}. Instead received a ${type}.`
+            `${name} must be ${expectedTypes.length > 1 ? 'one of' : 'a'} ${expectedTypes}. Instead received a ${type}.`
           )
         }
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -2264,10 +2264,11 @@ describe('React', () => {
         return new RegExp(str.replace(/([\[\]\{\}\(\)\.\-\,\+\?\*])/g, '\\$1'))
       }
 
-      function typecheckCheck(name, expectedType, typeException = null) {
+      function typecheckCheck(name, expectedTypes, typeException = null) {
+        expectedTypes = Array.isArray(expectedTypes) ? expectedTypes : [ expectedTypes ]
         typeException = typeException || function (type) {
           return regexpify(
-            `${name} must be a ${expectedType}. Instead received a ${type}.`
+            `${name} must be a ${expectedTypes}. Instead received a ${type}.`
           )
         }
 
@@ -2283,8 +2284,8 @@ describe('React', () => {
 
         for (let type in checks) {
           let values = checks[type]
-          if (type === expectedType) { return }
-          if (expectedType === 'plain object with string values' &&
+          if (expectedTypes.some(t => t === type)) { return }
+          if (expectedTypes.some(t => t === 'plain object with string values') &&
             type === 'object') { values = values.slice(0, 3) }
 
           values.forEach(value => {
@@ -2302,20 +2303,20 @@ describe('React', () => {
         typecheckCheck('handleResponse', 'function')
       })
 
-      it('should throw unless a function is given as then', () => {
-        typecheckCheck('then', 'function')
+      it('should throw unless a function or undefined is given as then', () => {
+        typecheckCheck('then', [ 'function', 'undefined' ])
       })
 
-      it('should throw unless a function is given as andThen', () => {
-        typecheckCheck('andThen', 'function')
+      it('should throw unless a function or undefined is given as andThen', () => {
+        typecheckCheck('andThen', [ 'function', 'undefined' ])
       })
 
-      it('should throw unless a function is given as catch', () => {
-        typecheckCheck('catch', 'function')
+      it('should throw unless a function or undefined is given as catch', () => {
+        typecheckCheck('catch', [ 'function', 'undefined' ])
       })
 
-      it('should throw unless a function is given as andCatch', () => {
-        typecheckCheck('andCatch', 'function')
+      it('should throw unless a function or undefined is given as andCatch', () => {
+        typecheckCheck('andCatch', [ 'function', 'undefined' ])
       })
 
       it('should throw unless a function is given as fetch', () => {


### PR DESCRIPTION
- extended `typecheck` function to support more than on allowed type
- extended `typecheckCheck` test function to support more than one allowed type