### PR TITLE
Fix cachingFetch example in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -532,18 +532,19 @@ import { connect } from 'react-refetch'
 const cache = new Map()
 function cachingFetch(input, init) {
   const req = new Request(input, init)
-  const inAMinute = 60000 + new Date()
+  const now = new Date().getTime()
+  const inAMinute = 60000 + now
   const cached = cache.get(req.url)
 
   if (cached && cached.time < inAMinute) {
-    return cached.response.clone()
+    return new Promise(resolve => resolve(cached.response.clone()))
   }
 
   return fetch(req).then(response => {
     cache.set(req.url, {
-      time: new Date(),
+      time: now,
       response: response.clone()
-    })
+    });
 
     return response
   })

--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ function cachingFetch(input, init) {
     cache.set(req.url, {
       time: now,
       response: response.clone()
-    });
+    })
 
     return response
   })


### PR DESCRIPTION
cachingFetch example is not working for 2 reasons:

- `new Date() + 60000` won't work, date needs to be casted to timestamp first otherwise it returns something like `Wed Jun 15 2016 16:25:57 GMT+0200 (CEST)60000`
- the returned value has to be a promise