### PR TITLE
Adds .babelrc to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 src
 examples
+.babelrc


### PR DESCRIPTION
I'm using React Native which is not precompiled (nor most of its third party libraries) I need to apply babel to npm dependencies and since babel tries to use configs for each package if present, the presence of it here breaks my setup.