### PR TITLE
Don't setTimeout if component is unmounted.

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -314,7 +314,7 @@ function connect(mapPropsToRequestsToProps, defaults, options) {
         return (meta) => {
           return (value) => {
             let refreshTimeout = null
-            if (mapping.refreshInterval > 0) {
+            if (mapping.refreshInterval > 0 && !this._unmounted) {
               refreshTimeout = window.setTimeout(() => {
                 this.refetchDatum(prop, Object.assign({}, mapping, { refreshing: true, force: true }))
               }, mapping.refreshInterval)


### PR DESCRIPTION
Fixes https://github.com/heroku/react-refetch/issues/166

This happens in the case where the previous fetch hasn't resolved yet
and the component is unmounted. In that case it keeps refreshing the
unmounted component forever.

Also includes fix for unrelated non-deterministic test that occurs because
the test assumes that two different lines in the test will take place more
than one millisecond apart, which is not always true.