### PR TITLE
Allow headers to be specified as functions.

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -161,7 +161,9 @@ function connect(mapPropsToRequestsToProps, defaults, options) {
     for (let key in rawHeaders) {
       // Discard headers with falsy values
       if (rawHeaders.hasOwnProperty(key) && rawHeaders[key]) {
-        headers[key] = rawHeaders[key]
+        // Get the value now if the header is specified as a function
+        const headerValue = typeof rawHeaders[key] == 'function' ? rawHeaders[key]() : rawHeaders[key]
+        headers[key] = headerValue
       }
     }
 

--- a/test/components/connect.spec.js
+++ b/test/components/connect.spec.js
@@ -2640,7 +2640,9 @@ describe('React', () => {
 
         const headers = { 'X-Foo': () => props.abc }
         const custom = connect.defaults({ fetch: customFetch, headers })
-        @custom((props) => ({ testFetch: { url:`/example`, force: true } }))
+
+        // Props is needed or else the component doesn't try and refresh
+        @custom((props) => ({ testFetch: { url:`/example` } })) // eslint-disable-line
         class Container extends Component {
           render() {
             return <Passthrough {...this.props} />


### PR DESCRIPTION
I couldn't find a workaround for #171 without making a library change. This allows you to set a dynamic header value while setting up defaults. I considered making the entire `headers` object a function but that required many more changes that I didn't want to mess with since there are various places that it is treated specifically as an object.

E.g:
```
connect.defaults({
  headers: {
    "token": () => localStorage.getItem("token")
  }
})
```