### PR TITLE
Fix refreshing using wrong props when the props change before a previous refresh has finished

### DIFF
--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -317,7 +317,7 @@ function connect(mapPropsToRequestsToProps, defaults, options) {
         return (meta) => {
           return (value) => {
             let refreshTimeout = null
-            if (mapping.refreshInterval > 0 && !this._unmounted) {
+            if (mapping.refreshInterval > 0 && !this._unmounted && this.state.mappings[prop] === mapping) {
               refreshTimeout = window.setTimeout(() => {
                 this.refetchDatum(prop, Object.assign({}, mapping, { refreshing: true, force: true }))
               }, mapping.refreshInterval)


### PR DESCRIPTION
References #180 

Note on the fix: 
I'm not sure this is the proper way to fix it, but it seems to work for my use case and passes all tests. An alternative would be to keep track somehow if the result of a timeout is `valid` or not.

I tried to come up with a meaningful test, but was unable to because of the asynchronous nature. If someone could help that would be awesome.

Problem:
The problem is that when a timeout is resolved, it cancel's any previously queued timeouts.

Ordering:
Old timeout in progress
Props change and sets up a new timeout
Old timeout resolves and cancels new timeout
Old timeout now creates a new timeout with old properties
Subsequent refreshes are all incorrect

Setup:
```
connect(props => ({
  dataFetch: {
    url: `api/${props.id}`
    refreshInterval: 5000
  }
}))(...)
```

Steps:

Load the component.
Wait for a refresh and before the refresh finishes resolving:
Update the props to the component to change id. (don't unmount/remount, just update the props).

Previous Result:
It calls /api/new-id once but then the refresh finishes and all subsequent refreshes are called with api/old-id.

New Result:
It calls /api/new-id on all subsequent refreshes.