### PR TITLE
feat: add ability to provide function in identity requests (fixes #177)

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,7 +329,17 @@ connect(props => ({
 
 Note, this form of transformation is similar to what is possible on the `PromiseState` (i.e. `this.props.usersFetch.then(users => users.filter(u => u.verified))`); however, this has the advantage of only being called when `usersFetch` changes and keeps the logic out of the component.
 
-**Identity requests can also be provided a `Promise` or thenable.** In this case, the `PromiseState` will be `pending` until the `Promise` is resolved. This can be helpful for asynchronous, non-fetch operations (e.g. file i/o) that want to use a similar pattern as fetch operations.
+**Identity requests can also be provided a `Promise`/thenable or a `Function`.**
+In case of a `Promise`, the `PromiseState` will be `pending` until the `Promise` is resolved. This can be helpful for asynchronous, non-fetch operations (e.g. file i/o) that want to use a similar pattern as fetch operations.
+In case of a `Function`, value returned from it will be used instead, as in cases described above. `Function` will be only be called when `comparison` changed.
+
+```jsx
+connect(props => ({
+  usersFetch: {
+    value: () => someAPI.list('/users')
+  }
+}))(Users)
+```
 
 ## Accessing Headers & Metadata
 
@@ -564,7 +574,7 @@ This is an _advanced feature_. Use existing declarative functionality wherever p
 
 ## Unit Testing Connected Components
 
-For unit testing components connected, a non-default export of the unconnected component can be exposed to allow unit tests to inject their own `PromiseState`(s) as props. This allows for unit tests to test both success and error scenarios without having to deal with mocking HTTP, timing of responses, or other details about how the `PromiseState`(s) is fulfilled -- instead, they can just focus on asserting that the component itself renders the `PromiseState`(s) correctly in various scenarios. 
+For unit testing components connected, a non-default export of the unconnected component can be exposed to allow unit tests to inject their own `PromiseState`(s) as props. This allows for unit tests to test both success and error scenarios without having to deal with mocking HTTP, timing of responses, or other details about how the `PromiseState`(s) is fulfilled -- instead, they can just focus on asserting that the component itself renders the `PromiseState`(s) correctly in various scenarios.
 
 The recommended naming convention for the unconnected component is to prepend an underscore to the component name. For example, if there is a component called `Profile`, add a non-default export of `_Profile` before the default export with `connect`:
 
@@ -576,7 +586,7 @@ class Profile extends React.Component {
 
   render() {
     const { userFetch } = this.props
-    
+
     if (userFetch.pending) {
       return <LoadingAnimation/>
     } else if (userFetch.rejected) {

--- a/docs/api.md
+++ b/docs/api.md
@@ -4,7 +4,7 @@
 
 Connects a React component to data from one or more URLs.
 
-It does not modify the component class passed to it.  
+It does not modify the component class passed to it.
 Instead, it *returns* a new, connected component class, for you to use.
 
 #### Arguments
@@ -26,10 +26,10 @@ Instead, it *returns* a new, connected component class, for you to use.
      - `catch(reason, meta): request` *(Function)*: returns a request to fetch after rejection of this request and replaces this request. Takes the `value` and `meta` of this request as arguments. Return `undefined` in `catch` to do side-effects after a rejected request, leaving the request as is.
      - `andThen(value, meta): { prop: request, ... }` *(Function)*: returns an object of request mappings to fetch after fulfillment of this request but does not replace this request. Takes the `value` and `meta` of this request as arguments.
      - `andCatch(reason, meta): { prop: request, ... }` *(Function)*: returns an object of request mappings to fetch after rejection of this request but does not replace this request. Takes the `value` and `meta` of this request as arguments.
-     - `value` *(Any)*: Data to passthrough directly to `PromiseState` as an alternative to providing a URL. If given a `Promise`, the `PromiseState` will be pending until the `value` or `reason` is settled; otherwise, the `PromiseState` will be resolved immediately. This is an advanced option used for static data and data transformations. Also consider setting `meta`.
+     - `value` *(Function => Any | Any)*: Data to passthrough directly to `PromiseState` as an alternative to providing a URL. Given a `Function`, its return value will be passed to `PromiseState`. If given a `Promise` (or `Promise` returned from `Function`), the `PromiseState` will be pending until the `value` or `reason` is settled; otherwise, the `PromiseState` will be resolved immediately. This is an advanced option used for static data and data transformations. Also consider setting `meta`.
      - `meta` *(Object)*: Metadata to passthrough directly to `PromiseState`. Keys `request`, `response`, `component`, and future keys may be overwritten.
-     
-   The arguments `then`, `andThen`, `catch`, `andCatch` above take  `value`/`reason` and `meta` as arguments. These coorespond to the properties of the `PromiseState` described below. `meta` contains a `component` property that is equal to the component being wrapped. You can use it to create side effects on promise fulfillment. e.g. `then(value, meta) { meta.component.onDataLoaded(value); }`. Note, `component` is only set if `withRef: true` in options; otherwise, it will be `undefined`.
+
+   The arguments `then`, `andThen`, `catch`, `andCatch` above take  `value`/`reason` and `meta` as arguments. These correspond to the properties of the `PromiseState` described below. `meta` contains a `component` property that is equal to the component being wrapped. You can use it to create side effects on promise fulfillment. e.g. `then(value, meta) { meta.component.onDataLoaded(value); }`. Note, `component` is only set if `withRef: true` in options; otherwise, it will be `undefined`.
 
   The following keys may also be defined on an individual request (see their description below at `connect.defaults()`):
      - `fetch`

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -274,11 +274,16 @@ function connect(mapPropsToRequestsToProps, defaults, options) {
         const onRejection = this.createPromiseStateOnRejection(prop, mapping, startedAt)
 
         if (mapping.hasOwnProperty('value')) {
-          if (hasIn(mapping.value, 'then')) {
+          let value = mapping.value
+          if (typeof value === 'function') {
+            value = value()
+          }
+
+          if (hasIn(value, 'then')) {
             this.setAtomicState(prop, startedAt, mapping, initPS(meta))
-            return mapping.value.then(onFulfillment(meta), onRejection(meta))
+            return value.then(onFulfillment(meta), onRejection(meta))
           } else {
-            return onFulfillment(meta)(mapping.value)
+            return onFulfillment(meta)(value)
           }
         } else {
           const request = mapping.buildRequest(mapping)


### PR DESCRIPTION
This PR fixes #177

It's now possible to pass a function to identity request's `value` prop:
```js
const fetchUser = id => fetch(`/users/${id}`);

connect(props => ({
  user: {
    value: () => fetchUser(props.match.params.id),
    comparison: props.match.params.id
  }
}))(Profile);
```