### PR TITLE
remove lodash to shrink bundle size

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4246,7 +4246,8 @@
     "lodash": {
       "version": "4.17.4",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+      "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+      "dev": true
     },
     "lodash._arraycopy": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
   "dependencies": {
     "hoist-non-react-statics": "^2.2.1",
     "invariant": "^2.0.0",
-    "lodash": "^4.2.0",
     "warning": "^3.0.0"
   },
   "peerDependencies": {

--- a/src/components/connect.js
+++ b/src/components/connect.js
@@ -8,8 +8,6 @@ import PromiseState from '../PromiseState'
 import hoistStatics from 'hoist-non-react-statics'
 import invariant from 'invariant'
 import warning from 'warning'
-import hasIn from 'lodash/hasIn'
-import omit from 'lodash/fp/omit'
 
 const defaultMapPropsToRequestsToProps = () => ({})
 
@@ -61,7 +59,10 @@ export default connectFactory({
   }
 })
 
-const omitChildren = omit('children')
+const omitChildren = function omitChildren(obj) {
+  const { children, ...rest } = obj
+  return rest
+}
 
 function connect(mapPropsToRequestsToProps, defaults, options) {
   const finalMapPropsToRequestsToProps = mapPropsToRequestsToProps || defaultMapPropsToRequestsToProps
@@ -272,9 +273,8 @@ function connect(mapPropsToRequestsToProps, defaults, options) {
         const initPS = this.createInitialPromiseState(prop, mapping)
         const onFulfillment = this.createPromiseStateOnFulfillment(prop, mapping, startedAt)
         const onRejection = this.createPromiseStateOnRejection(prop, mapping, startedAt)
-
         if (mapping.hasOwnProperty('value')) {
-          if (hasIn(mapping.value, 'then')) {
+          if ('then' in Object(mapping.value)) {
             this.setAtomicState(prop, startedAt, mapping, initPS(meta))
             return mapping.value.then(onFulfillment(meta), onRejection(meta))
           } else {


### PR DESCRIPTION
I added `react-refetch` to my app to playaround with it. Very nice! 

I noticed my bundle size increased a lot. Using `webpack-budle-analyzer` i found out that `react-refetch` included a good portion of lodash.

This PR replaces lodash with simpler methods to decrease the bundled size dramatically.


Before
![before](https://i.imgur.com/W0QQ4Uy.png)

After
![after](https://i.imgur.com/WxR33oO.png)
