### PR TITLE
Fixed bug in the "caching fetch" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,10 +547,10 @@ const cache = new Map()
 function cachingFetch(input, init) {
   const req = new Request(input, init)
   const now = new Date().getTime()
-  const inAMinute = 60000 + now
+  const oneMinuteAgo = now - 60000
   const cached = cache.get(req.url)
 
-  if (cached && cached.time < inAMinute) {
+  if (cached && cached.time < oneMinuteAgo) {
     return new Promise(resolve => resolve(cached.response.clone()))
   }
 


### PR DESCRIPTION
The condition was always true; the cached request can't really have been made one minute into the future (>= now+60000). The correct comparison is one minute into the past