### PR TITLE
Improve type definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -21,14 +21,12 @@ export interface PromiseStateStatic {
   race<T = {}>(iterable: Iterable<PromiseState<any>>): PromiseState<T>;
 }
 
-export interface PromiseState<T = {}> {
+interface PromiseStateBase<T = {}> {
   readonly pending: boolean;
   readonly refreshing: boolean;
   readonly fulfilled: boolean;
   readonly rejected: boolean;
   readonly settled: boolean;
-  readonly value: T;
-  readonly reason: any;
   readonly meta: any;
   then: <TFulfilled = T, TRejected = T>(
     onFulfilled?: (
@@ -43,6 +41,28 @@ export interface PromiseState<T = {}> {
     onRejected?: (reason: any) => PromiseStateLike<TRejected>,
   ) => PromiseStateLike<T> | PromiseStateLike<TRejected>;
 }
+
+export interface PendingPromiseState<T = {}> extends PromiseStateBase {
+  readonly pending: true;
+  readonly fulfilled: false;
+  readonly rejected: false;
+}
+
+export interface FulfilledPromiseState<T = {}> extends PromiseStateBase {
+  readonly pending: false;
+  readonly fulfilled: true;
+  readonly rejected: false;
+  readonly value: T;
+}
+
+export interface RejectedPromiseState<T = {}> extends PromiseStateBase {
+  readonly pending: false;
+  readonly fulfilled: false;
+  readonly rejected: true;
+  readonly reason: any;
+}
+
+export type PromiseState<T = {}> = PendingPromiseState<T>
 
 export const PromiseState: Readonly<PromiseStateStatic>;
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,10 +13,11 @@ import {
 export type PromiseStateLike<T> = T | PromiseState<T>;
 
 export interface PromiseStateStatic {
-  create<T = {}>(meta?: any): PromiseState<T>;
-  refresh<T = {}>(previous?: PromiseState<T>, meta?: any): PromiseState<T>;
-  resolve<T = {}>(value?: PromiseStateLike<T>, meta?: any): PromiseState<T>;
-  reject<T = {}>(reason?: any, meta?: any): PromiseState<T>;
+  create<T = {}>(meta?: any): PendingPromiseState<T>;
+  refresh<T = {}>(previous: undefined, meta?: any): PendingPromiseState<T>;
+  refresh<T = {}, P extends PromiseState<T> = PromiseState<T>>(previous: P, meta?: any): P;
+  resolve<T = {}>(value?: PromiseStateLike<T>, meta?: any): FulfilledPromiseState<T>;
+  reject<T = {}>(reason?: any, meta?: any): RejectedPromiseState<T>;
   all<T = {}>(iterable: Iterable<PromiseState<any>>): PromiseState<T[]>;
   race<T = {}>(iterable: Iterable<PromiseState<any>>): PromiseState<T>;
 }
@@ -62,7 +63,7 @@ export interface RejectedPromiseState<T = {}> extends PromiseStateBase {
   readonly reason: any;
 }
 
-export type PromiseState<T = {}> = PendingPromiseState<T>
+export type PromiseState<T = {}> = PendingPromiseState<T> | FulfilledPromiseState<T> | RejectedPromiseState<T>;
 
 export const PromiseState: Readonly<PromiseStateStatic>;
 


### PR DESCRIPTION
This change improve TS type definition bundled in react-refetch.

## Background

Follow code will throw TypeError, since `userFetch.value` is undefined until data is loaded.

```tsx
render() {
  return <span>{ this.props.userFetch.value.name }</span>
}
```

It's better to detect this kind of bug by type-checking

## Solution

This change split `PromiseState` into 3 types, `PendingPromiseState`, `FulfilledPromiseState`, and `RejectedPromiseState`.
The property `value` exists only in `FulfilledPromiseState`. Therefore, before checking whether `promiseState` is `FulfilledPromiseState` instance or not, accessinig `promiseState.value` become compile-error. 

```tsx
render() {
  if (!this.props.userFetch.fulfilled) {
    return <span>Loading...</span>
  }

  // Here, TS compiler knows "userFetch" is "FulfilledPromiseState" instance, because "uerFetch.fulfilled" is "true"
  return <span>{ this.props.userFetch.value.name }</span>
}
```