### PR TITLE
TypeScript: Improve type definition to use optional chaining

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -47,6 +47,8 @@ export interface PendingPromiseState<T = {}> extends PromiseStateBase {
   readonly pending: true;
   readonly fulfilled: false;
   readonly rejected: false;
+  readonly value: undefined;
+  readonly reason: undefined;
 }
 
 export interface FulfilledPromiseState<T = {}> extends PromiseStateBase {
@@ -54,12 +56,14 @@ export interface FulfilledPromiseState<T = {}> extends PromiseStateBase {
   readonly fulfilled: true;
   readonly rejected: false;
   readonly value: T;
+  readonly reason: undefined;
 }
 
 export interface RejectedPromiseState<T = {}> extends PromiseStateBase {
   readonly pending: false;
   readonly fulfilled: false;
   readonly rejected: true;
+  readonly value: undefined;
   readonly reason: any;
 }
 


### PR DESCRIPTION
[Optional Chaining](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#optional-chaining) is the syntax in upcoming ECMAScript and introduced in TypeScript v3.7.

In #240, I(Sorry, account is different but it's me) changed react-refetch's type definition so that unsafe access can be detected by TS compiler.

```ts
render() {
  if (!this.props.userFetch.fulfilled) {
    return <span>Loading...</span>
  }

  // Here, TS compiler knows "userFetch" is "FulfilledPromiseState" instance, because "uerFetch.fulfilled" is "true"
  return <span>{ this.props.userFetch.value.name }</span>
}
```

However, sometimes people want to simplify this by using optional chaining

```ts
render() {
  return <span>{ this.props.userFetch.value?.name || 'Loading...' }</span>
}
```

This PR improve type definition so that all `PromiseState` type have value field to use optional chaining for generic `PromiseState` type.
