### PR TITLE
Upgrade GitHub Actions Node Test Versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [8.x, 10.x, 12.x, 14.x, 15.x]
+        node-version: [14.x, 15.x, 16.x, 18.x, 19.x, 20.x]
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Heroku
+Copyright (c) 2023 Heroku
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -26,7 +26,7 @@ License for portions of React Redux project from which this was derived:
 
 The MIT License (MIT)
 
-Copyright (c) 2015 Dan Abramov
+Copyright (c) 2023 Dan Abramov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
It's been a few years, and Node has progressed forward. This upgrades the tested Node versions to those currently in maintenance, active, and current status on the [Node website](https://nodejs.dev/en/about/releases/), as of the commit date.